### PR TITLE
Expose all Summary defaults as public

### DIFF
--- a/Prometheus.NetStandard/Advanced/MetricFactory.cs
+++ b/Prometheus.NetStandard/Advanced/MetricFactory.cs
@@ -31,14 +31,7 @@ namespace Prometheus.Advanced
             return (Summary)_registry.GetOrAdd(metric);
         }
 
-        public Summary CreateSummary(
-            string name,
-            string help,
-            string[] labelNames,
-            IList<QuantileEpsilonPair> objectives = null,
-            TimeSpan? maxAge = null,
-            int? ageBuckets = null,
-            int? bufCap = null)
+        public Summary CreateSummary(string name, string help, string[] labelNames, IList<QuantileEpsilonPair> objectives, TimeSpan? maxAge, int? ageBuckets, int? bufCap)
         {
             var metric = new Summary(name, help, labelNames, objectives, maxAge, ageBuckets, bufCap);
             return (Summary)_registry.GetOrAdd(metric);

--- a/Prometheus.NetStandard/Advanced/MetricFactory.cs
+++ b/Prometheus.NetStandard/Advanced/MetricFactory.cs
@@ -31,7 +31,14 @@ namespace Prometheus.Advanced
             return (Summary)_registry.GetOrAdd(metric);
         }
 
-        public Summary CreateSummary(string name, string help, string[] labelNames, IList<QuantileEpsilonPair> objectives, TimeSpan maxAge, int? ageBuckets, int? bufCap)
+        public Summary CreateSummary(
+            string name,
+            string help,
+            string[] labelNames,
+            IList<QuantileEpsilonPair> objectives = null,
+            TimeSpan? maxAge = null,
+            int? ageBuckets = null,
+            int? bufCap = null)
         {
             var metric = new Summary(name, help, labelNames, objectives, maxAge, ageBuckets, bufCap);
             return (Summary)_registry.GetOrAdd(metric);

--- a/Prometheus.NetStandard/Metrics.cs
+++ b/Prometheus.NetStandard/Metrics.cs
@@ -24,14 +24,7 @@ namespace Prometheus
             return DefaultFactory.CreateSummary(name, help, labelNames);
         }
 
-        public static Summary CreateSummary(
-            string name,
-            string help,
-            string[] labelNames,
-            IList<QuantileEpsilonPair> objectives = null,
-            TimeSpan? maxAge = null,
-            int? ageBuckets = null,
-            int? bufCap = null)
+        public static Summary CreateSummary(string name, string help, string[] labelNames, IList<QuantileEpsilonPair> objectives, TimeSpan? maxAge, int? ageBuckets, int? bufCap)
         {
             return DefaultFactory.CreateSummary(name, help, labelNames, objectives, maxAge, ageBuckets, bufCap);
         }

--- a/Prometheus.NetStandard/Metrics.cs
+++ b/Prometheus.NetStandard/Metrics.cs
@@ -24,7 +24,14 @@ namespace Prometheus
             return DefaultFactory.CreateSummary(name, help, labelNames);
         }
 
-        public static Prometheus.Summary CreateSummary(string name, string help, string[] labelNames, IList<QuantileEpsilonPair> objectives, TimeSpan maxAge, int? ageBuckets, int? bufCap)
+        public static Summary CreateSummary(
+            string name,
+            string help,
+            string[] labelNames,
+            IList<QuantileEpsilonPair> objectives = null,
+            TimeSpan? maxAge = null,
+            int? ageBuckets = null,
+            int? bufCap = null)
         {
             return DefaultFactory.CreateSummary(name, help, labelNames, objectives, maxAge, ageBuckets, bufCap);
         }

--- a/Prometheus.NetStandard/Summary.cs
+++ b/Prometheus.NetStandard/Summary.cs
@@ -27,13 +27,13 @@ namespace Prometheus
         };
 
         // Default duration for which observations stay relevant
-        static readonly TimeSpan DefMaxAge = TimeSpan.FromMinutes(10);
+        public static readonly TimeSpan DefMaxAge = TimeSpan.FromMinutes(10);
 
         // Default number of buckets used to calculate the age of observations
-        const int DefAgeBuckets = 5;
+        public static readonly int DefAgeBuckets = 5;
 
         // Standard buffer size for collecting Summary observations
-        const int DefBufCap = 500;
+        public static readonly int DefBufCap = 500;
 
         readonly IList<QuantileEpsilonPair> _objectives;
         readonly TimeSpan _maxAge;


### PR DESCRIPTION
This PR caters to a use case where the user would like to create a summary metric with mostly default parameters. Currently it's tricky because the more configurable overload requires specifying all the parameters. Even if the user figures out the current defaults, there's no way to indefinitely match them as this library may decide to change them in the future.

Since `Summary.DefObjectives` is already public, I propose also making the following defaults public:

- `Summary.DefMaxAge`
- `Summary.DefAgeBuckets`
- `Summary.DefBufCap`

It feels more cohesive if all the defaults are handled in a similar way. With that in mind, the values should also be marked `static readonly` instead of `const` so that they are always properly taken from this assembly at runtime.