### PR TITLE
Create new CancellationTokenSource on each start

### DIFF
--- a/Prometheus.NetStandard/MetricHandler.cs
+++ b/Prometheus.NetStandard/MetricHandler.cs
@@ -16,7 +16,7 @@ namespace Prometheus
         protected readonly ICollectorRegistry _registry;
 
         // The token is cancelled when the handler is instructed to stop.
-        private CancellationTokenSource _cts = new CancellationTokenSource();
+        private CancellationTokenSource _cts;
 
         // This is the task started for the purpose of exporting metrics.
         private Task _task;
@@ -30,7 +30,8 @@ namespace Prometheus
         {
             if (_task != null)
                 throw new InvalidOperationException("The metric server has already been started.");
-
+            
+            _cts = new CancellationTokenSource();
             _task = StartServer(_cts.Token);
             return this;
         }


### PR DESCRIPTION
Now you are able to restart the MetricServer.. else the CTS is null