### PR TITLE
Decoupling MetricPushService functionality from MetricsPusher background worker implementation

### DIFF
--- a/Prometheus.NetStandard/MetricPushService.cs
+++ b/Prometheus.NetStandard/MetricPushService.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Prometheus.Advanced.DataContracts;
+
+namespace Prometheus
+{
+    public class MetricPushService : IMetricPushService
+    {
+        private readonly HttpClient _httpClient;
+
+        public const string ContentType = "text/plain; version=0.0.4";
+
+        protected virtual HttpMessageHandler MessageHandler => new HttpClientHandler();
+
+        public MetricPushService()
+        {
+            _httpClient = new HttpClient(MessageHandler);
+        }
+
+        /// <summary>
+        /// Push metrics to single pushgateway endpoint
+        /// </summary>
+        /// <param name="metricFamilies">Collection of metrics</param>
+        /// <param name="endpoint">PushGateway endpoint</param>
+        /// <param name="job">job name</param>
+        /// <param name="instance">instance name</param>
+        /// <param name="contentType">content-type</param>
+        /// <param name="additionalLabels">additional labels</param>
+        /// <returns></returns>
+        public async Task PushAsync(IEnumerable<MetricFamily> metricFamilies, string endpoint, string job, string instance, string contentType = ContentType, IEnumerable<Tuple<string, string>> additionalLabels = null)
+        {
+            await PushAsync(metricFamilies, new[] { endpoint }, job, instance, contentType, additionalLabels).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Push metrics to single pushgateway endpoint
+        /// </summary>
+        /// <param name="metrics">Collection of metrics</param>
+        /// <param name="endpoints">PushGateway endpoints - fault-tolerance</param>
+        /// <param name="job">job name</param>
+        /// <param name="instance">instance name</param>
+        /// <param name="contentType">content-type</param>
+        /// <param name="additionalLabels">additional labels</param>
+        /// <returns></returns>
+        public async Task PushAsync(IEnumerable<MetricFamily> metrics, string[] endpoints, string job, string instance, string contentType = ContentType, IEnumerable<Tuple<string, string>> additionalLabels = null)
+        {
+            if (endpoints == null || !endpoints.Any())
+            {
+                throw new ArgumentNullException(nameof(endpoints));
+            }
+
+            if (string.IsNullOrEmpty(job))
+            {
+                throw new ArgumentNullException(nameof(job));
+            }
+
+            var tasks = new List<Task<HttpResponseMessage>>(endpoints.Length);
+            var streamsToDispose = new List<Stream>();
+
+            foreach (var endpoint in endpoints)
+            {
+                if (string.IsNullOrEmpty(endpoint))
+                {
+                    throw new ArgumentNullException(nameof(endpoint));
+                }
+
+                var url = $"{endpoint.TrimEnd('/')}/metrics/job/{job}";
+                if (!string.IsNullOrEmpty(instance))
+                {
+                    url = $"{url}/instance/{instance}";
+                }
+
+                var sb = new StringBuilder();
+                sb.Append(url);
+                if (additionalLabels != null)
+                {
+                    foreach (var pair in additionalLabels)
+                    {
+                        if (pair == null || string.IsNullOrEmpty(pair.Item1) || string.IsNullOrEmpty(pair.Item2))
+                        {
+                            // TODO: Surely this should throw an exception?
+                            Trace.WriteLine("Ignoring invalid label set");
+                            continue;
+                        }
+
+                        sb.AppendFormat("/{0}/{1}", pair.Item1, pair.Item2);
+                    }
+                }
+
+                if (!Uri.TryCreate(sb.ToString(), UriKind.Absolute, out var targetUrl))
+                {
+                    throw new ArgumentException("Endpoint must be a valid url", nameof(endpoint));
+                }
+
+                var memoryStream = new MemoryStream();
+                streamsToDispose.Add(memoryStream);
+                ScrapeHandler.ProcessScrapeRequest(metrics, contentType, memoryStream);
+                memoryStream.Position = 0;
+
+                if (string.IsNullOrEmpty(endpoint))
+                {
+                    throw new ArgumentNullException(nameof(endpoint));
+                }
+
+                var streamContent = new StreamContent(memoryStream);
+                tasks.Add(_httpClient.PostAsync(targetUrl, streamContent));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            Exception exception = null;
+            foreach (var task in tasks)
+            {
+                var response = await task.ConfigureAwait(false);
+                try
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+            }
+
+            streamsToDispose.ForEach(s => s.Dispose());
+
+            if (exception != null)
+            {
+                throw exception;
+            }
+        }
+    }
+
+    public interface IMetricPushService
+    {
+        /// <summary>
+        /// Push metrics to single pushgateway endpoint
+        /// </summary>
+        /// <param name="metricFamilies">Collection of metrics</param>
+        /// <param name="endpoint">PushGateway endpoint</param>
+        /// <param name="job">job name</param>
+        /// <param name="instance">instance name</param>
+        /// <param name="contentType">content-type</param>
+        /// <param name="additionalLabels">additional labels</param>
+        /// <returns></returns>
+        Task PushAsync(IEnumerable<MetricFamily> metricFamilies, string endpoint, string job, string instance,
+            string contentType = MetricPushService.ContentType, IEnumerable<Tuple<string, string>> additionalLabels = null);
+
+        /// <summary>
+        /// Push metrics to single pushgateway endpoint
+        /// </summary>
+        /// <param name="metrics">Collection of metrics</param>
+        /// <param name="endpoints">PushGateway endpoints - fault-tolerance</param>
+        /// <param name="job">job name</param>
+        /// <param name="instance">instance name</param>
+        /// <param name="contentType">content-type</param>
+        /// <param name="additionalLabels">additional labels</param>
+        /// <returns></returns>
+        Task PushAsync(IEnumerable<MetricFamily> metrics, string[] endpoints, string job, string instance,
+            string contentType = MetricPushService.ContentType, IEnumerable<Tuple<string, string>> additionalLabels = null);
+    }
+}

--- a/Prometheus.NetStandard/MetricPushService.cs
+++ b/Prometheus.NetStandard/MetricPushService.cs
@@ -102,12 +102,6 @@ namespace Prometheus
                 streamsToDispose.Add(memoryStream);
                 ScrapeHandler.ProcessScrapeRequest(metrics, contentType, memoryStream);
                 memoryStream.Position = 0;
-
-                if (string.IsNullOrEmpty(endpoint))
-                {
-                    throw new ArgumentNullException(nameof(endpoint));
-                }
-
                 var streamContent = new StreamContent(memoryStream);
                 tasks.Add(_httpClient.PostAsync(targetUrl, streamContent));
             }

--- a/Resources/SolutionAssemblyInfo.cs
+++ b/Resources/SolutionAssemblyInfo.cs
@@ -2,10 +2,10 @@
 using System.Runtime.CompilerServices;
 
 // This is the real version number, used in NuGet packages and for display purposes.
-[assembly: AssemblyFileVersion("2.1.1")]
+[assembly: AssemblyFileVersion("2.2.0")]
 
 // Only use major version here, with others kept at zero, for correct assembly binding logic.
-[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyVersion("2.2.0")]
 
 [assembly: InternalsVisibleTo("Tests.NetFramework")]
 [assembly: InternalsVisibleTo("Tests.NetCore")]

--- a/Tests.NetCore/PushMetricServiceTests.cs
+++ b/Tests.NetCore/PushMetricServiceTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prometheus.Advanced;
+
+namespace Prometheus.Tests
+{
+    [TestClass]
+    public class MetricPushServiceTest : BaseMetricPushServiceTest
+    {
+        private MockedMetricPushService _pushService;
+        private ICollectorRegistry _metrics;
+        private string _result;
+        public override void Act()
+        {
+            _pushService.PushAsync(_metrics.CollectAll(), "http://localhost:9091",
+                "pushgateway", Environment.MachineName, null).GetAwaiter().GetResult();
+        }
+
+        public override void Arrange()
+        {
+            _metrics = new DefaultCollectorRegistry();
+            var metricFactory = new MetricFactory(_metrics);
+            var counter = metricFactory.CreateCounter("test_counter", "just a simple test counter", "Color", "Size");
+            counter.Labels("White", "XXS").Inc();
+            counter.Labels("Black", "XXL").Inc();
+
+            _pushService = new MockedMetricPushService();
+            _pushService.Handler.SetMessageHandler((r) =>
+            {
+                var streamContent = r.Content as StreamContent;
+                _result = streamContent.ReadAsStringAsync().GetAwaiter().GetResult();
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+        }
+
+        [TestMethod]
+        public void should_send_metrics_and_get_success()
+        {
+            var memoryStream = new MemoryStream();
+            ScrapeHandler.ProcessScrapeRequest(_metrics.CollectAll(), null, memoryStream);
+            var expectedResult = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(expectedResult, _result);
+        }
+    }
+
+    public abstract class BaseMetricPushServiceTest
+    {
+        protected BaseMetricPushServiceTest()
+        {
+            Initialize();
+        }
+
+        public void Initialize()
+        {
+            Arrange();
+            Act();
+        }
+
+        public abstract void Act();
+        public abstract void Arrange();
+    }
+
+    public class MockedMetricPushService : MetricPushService
+    {
+        private readonly MessageHandler _messageHandler = new MessageHandler();
+        protected override HttpMessageHandler MessageHandler => Handler;
+        public MessageHandler Handler => _messageHandler;
+    }
+
+    public class MessageHandler : HttpMessageHandler
+    {
+        private Func<HttpRequestMessage, Task<HttpResponseMessage>> _handler;
+        public void SetMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return await _handler(request).ConfigureAwait(false);
+        }
+    }
+}

--- a/Tests.NetFramework/app.config
+++ b/Tests.NetFramework/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0" />
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="94bc3704cddfc263" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.3000.0" newVersion="3.0.3000.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/prometheus-net.sln
+++ b/prometheus-net.sln
@@ -8,8 +8,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Resources", "Resources\Reso
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.NetCore", "Tests.NetCore\Tests.NetCore.csproj", "{09EED3ED-25BF-4942-8428-383B51DA0D86}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.NetFramework", "Tests.NetFramework\Tests.NetFramework.csproj", "{A45A8238-966E-482D-BF1A-95A25BB3169B}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tester.NetFramework", "Tester.NetFramework\Tester.NetFramework.csproj", "{377A530B-43FA-4980-97DF-C21BB32B4F77}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tester.NetCore", "Tester.NetCore\Tester.NetCore.csproj", "{5CB67E67-72BD-4514-97D1-336F72F82BBF}"
@@ -24,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark.NetFramework", "Benchmark.NetFramework\Benchmark.NetFramework.csproj", "{CC15F858-BDFC-4995-97C4-D0C565BAB162}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.NetFramework", "Tests.NetFramework\Tests.NetFramework.csproj", "{6B21D0E7-AB23-41E2-B41C-7AA1BE2CC96A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,10 +41,6 @@ Global
 		{09EED3ED-25BF-4942-8428-383B51DA0D86}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09EED3ED-25BF-4942-8428-383B51DA0D86}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09EED3ED-25BF-4942-8428-383B51DA0D86}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A45A8238-966E-482D-BF1A-95A25BB3169B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A45A8238-966E-482D-BF1A-95A25BB3169B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A45A8238-966E-482D-BF1A-95A25BB3169B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A45A8238-966E-482D-BF1A-95A25BB3169B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{377A530B-43FA-4980-97DF-C21BB32B4F77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{377A530B-43FA-4980-97DF-C21BB32B4F77}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{377A530B-43FA-4980-97DF-C21BB32B4F77}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -61,6 +57,10 @@ Global
 		{CC15F858-BDFC-4995-97C4-D0C565BAB162}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC15F858-BDFC-4995-97C4-D0C565BAB162}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC15F858-BDFC-4995-97C4-D0C565BAB162}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B21D0E7-AB23-41E2-B41C-7AA1BE2CC96A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B21D0E7-AB23-41E2-B41C-7AA1BE2CC96A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B21D0E7-AB23-41E2-B41C-7AA1BE2CC96A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B21D0E7-AB23-41E2-B41C-7AA1BE2CC96A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Decoupling MetricPushService functionality from MetricsPusher background worker implementation.
The main reason to give opportunity to other devs to create different implementations of the worker as it can be IHostedService (Background jobs in aspnetcore) please read [here](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-2.1) or implement timer-based worker as alternative.
If you approve PR and publish a nuget package - I have AspNetCore PushHostedService that implements IHostedService and in addition I have complete AspnetCore project example and I can add to prometheus-net.AspNetCore.