### PR TITLE
Allow multiple metrics with the same name but with the different labels

### DIFF
--- a/Prometheus.NetStandard/Advanced/DefaultCollectorRegistry.cs
+++ b/Prometheus.NetStandard/Advanced/DefaultCollectorRegistry.cs
@@ -84,10 +84,6 @@ namespace Prometheus.Advanced
         {
             var key = $"{collector.Name}|{string.Join("|", collector.LabelNames ?? new string[] { })}";
             var collectorToUse = _collectors.GetOrAdd(key, collector);
-
-            if (!collector.LabelNames.SequenceEqual(collectorToUse.LabelNames))
-                throw new InvalidOperationException("Collector with same name must have same label names");
-
             return collectorToUse;
         }
 

--- a/Prometheus.NetStandard/Advanced/DefaultCollectorRegistry.cs
+++ b/Prometheus.NetStandard/Advanced/DefaultCollectorRegistry.cs
@@ -82,7 +82,8 @@ namespace Prometheus.Advanced
 
         public ICollector GetOrAdd(ICollector collector)
         {
-            var collectorToUse = _collectors.GetOrAdd(collector.Name, collector);
+            var key = $"{collector.Name}|{string.Join("|", collector.LabelNames ?? new string[] { })}";
+            var collectorToUse = _collectors.GetOrAdd(key, collector);
 
             if (!collector.LabelNames.SequenceEqual(collectorToUse.LabelNames))
                 throw new InvalidOperationException("Collector with same name must have same label names");


### PR DESCRIPTION
Goal of this PR is to have metrics like this:

```
my_app{"dependency=myservice1", "status=ok"}
my_app{"dependency=myservice2", "status=ok"}
my_app{"dependency=myservice3", "status=failed"}
```

With the current implementation it's not possible. 
So I changed the way how the keys for the collectors are going to be built.