### PR TITLE
Add Exponential and Linear histogram buckets functions

### DIFF
--- a/Prometheus.NetStandard/Histogram.cs
+++ b/Prometheus.NetStandard/Histogram.cs
@@ -106,5 +106,60 @@ namespace Prometheus
         }
 
         public void Publish() => Unlabelled.Publish();
+        
+        // From https://github.com/prometheus/client_golang/blob/master/prometheus/histogram.go
+        /// <summary>  
+        ///  Creates '<paramref name="count"/>' buckets, where the lowest bucket has an
+        ///  upper bound of '<paramref name="start"/>' and each following bucket's upper bound is '<paramref name="factor"/>'
+        ///  times the previous bucket's upper bound.
+        /// 
+        ///  The function throws if '<paramref name="count"/>' is 0 or negative, if '<paramref name="start"/>' is 0 or negative,
+        ///  or if '<paramref name="factor"/>' is less than or equal 1.
+        /// </summary>
+        /// <param name="start">The upper bound of the lowest bucket. Must be positive.</param>
+        /// <param name="factor">The factor to increase the upper bound of subsequent buckets. Must be greater than 1.</param>
+        /// <param name="count">The number of buckets to create. Must be positive.</param>
+        public static double[] ExponentialBuckets(double start, double factor, int count)
+        {
+            if (count <= 0) throw new ArgumentException($"{nameof(ExponentialBuckets)} needs a positive {nameof(count)}");
+            if (start <= 0) throw new ArgumentException($"{nameof(ExponentialBuckets)} needs a positive {nameof(start)}");
+            if (factor <= 1) throw new ArgumentException($"{nameof(ExponentialBuckets)} needs a {nameof(factor)} greater than 1");
+
+            var buckets = new double[count];
+
+            for (var i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = start;
+                start *= factor;
+            }
+
+            return buckets;
+        }
+        
+        // From https://github.com/prometheus/client_golang/blob/master/prometheus/histogram.go
+        /// <summary>  
+        ///  Creates '<paramref name="count"/>' buckets, where the lowest bucket has an
+        ///  upper bound of '<paramref name="start"/>' and each following bucket's upper bound is the upper bound of the
+        ///  previous bucket, incremented by '<paramref name="width"/>'
+        /// 
+        ///  The function throws if '<paramref name="count"/>' is 0 or negative.
+        /// </summary>
+        /// <param name="start">The upper bound of the lowest bucket.</param>
+        /// <param name="width">The width of each bucket (distance between lower and upper bound).</param>
+        /// <param name="count">The number of buckets to create. Must be positive.</param>
+        public static double[] LinearBuckets(double start, double width, int count)
+        {
+            if (count <= 0) throw new ArgumentException($"{nameof(LinearBuckets)} needs a positive {nameof(count)}");
+
+            var buckets = new double[count];
+
+            for (var i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = start;
+                start += width;
+            }
+
+            return buckets;
+        }
     }
 }

--- a/Tests.NetFramework/MetricsTests.cs
+++ b/Tests.NetFramework/MetricsTests.cs
@@ -205,6 +205,79 @@ namespace Prometheus.Tests
                 Assert.AreEqual("Bucket values must be increasing", ex.Message);
             }
         }
+        
+        [TestMethod]
+        public void histogram_exponential_buckets_are_correct()
+        {
+            var bucketsStart = 1.1;
+            var bucketsFactor = 2.4;
+            var bucketsCount = 4;
+
+            var buckets = Histogram.ExponentialBuckets(bucketsStart, bucketsFactor, bucketsCount);
+            
+            Assert.AreEqual(bucketsCount, buckets.Length);
+            Assert.AreEqual(1.1, buckets[0]);
+            Assert.AreEqual(2.64, buckets[1]);
+            Assert.AreEqual(6.336, buckets[2]);
+            Assert.AreEqual(15.2064, buckets[3]);
+        }
+        
+        [TestMethod]
+        public void histogram_exponential_buckets_with_non_positive_count_throws()
+        {
+            var bucketsStart = 1;
+            var bucketsFactor = 2;
+
+            Assert.ThrowsException<ArgumentException>(() => Histogram.ExponentialBuckets(bucketsStart, bucketsFactor, -1));
+            Assert.ThrowsException<ArgumentException>(() => Histogram.ExponentialBuckets(bucketsStart, bucketsFactor, 0));
+        }
+        
+        [TestMethod]
+        public void histogram_exponential_buckets_with_non_positive_start_throws()
+        {
+            var bucketsFactor = 2;
+            var bucketsCount = 5;
+
+            Assert.ThrowsException<ArgumentException>(() => Histogram.ExponentialBuckets(-1, bucketsFactor, bucketsCount));
+            Assert.ThrowsException<ArgumentException>(() => Histogram.ExponentialBuckets(0, bucketsFactor, bucketsCount));
+        }
+        
+        [TestMethod]
+        public void histogram_exponential_buckets_with__factor_less_than_one_throws()
+        {
+            var bucketsStart = 1;
+            var bucketsCount = 5;
+
+            Assert.ThrowsException<ArgumentException>(() => Histogram.ExponentialBuckets(bucketsStart, 0.9, bucketsCount));
+            Assert.ThrowsException<ArgumentException>(() => Histogram.ExponentialBuckets(bucketsStart, 0, bucketsCount));
+            Assert.ThrowsException<ArgumentException>(() => Histogram.ExponentialBuckets(bucketsStart, -1, bucketsCount));
+        }
+        
+        [TestMethod]
+        public void histogram_linear_buckets_are_correct()
+        {
+            var bucketsStart = 1.1;
+            var bucketsWidth = 2.4;
+            var bucketsCount = 4;
+
+            var buckets = Histogram.LinearBuckets(bucketsStart, bucketsWidth, bucketsCount);
+            
+            Assert.AreEqual(bucketsCount, buckets.Length);
+            Assert.AreEqual(1.1, buckets[0]);
+            Assert.AreEqual(3.5, buckets[1]);
+            Assert.AreEqual(5.9, buckets[2]);
+            Assert.AreEqual(8.3, buckets[3]);
+        }
+        
+        [TestMethod]
+        public void histogram_linear_buckets_with_non_positive_count_throws()
+        {
+            var bucketsStart = 1;
+            var bucketsWidth = 2;
+
+            Assert.ThrowsException<ArgumentException>(() => Histogram.LinearBuckets(bucketsStart, bucketsWidth, -1));
+            Assert.ThrowsException<ArgumentException>(() => Histogram.LinearBuckets(bucketsStart, bucketsWidth, 0));
+        }
 
         [TestMethod]
         public void summary_tests()


### PR DESCRIPTION
Useful helper functions for defining a set of buckets for histograms. Taken directly from the Go implementation [here](https://github.com/prometheus/client_golang/blob/master/prometheus/histogram.go)