### PR TITLE
add sample size option for building histogram;

### DIFF
--- a/Prometheus.NetStandard/Histogram.cs
+++ b/Prometheus.NetStandard/Histogram.cs
@@ -6,6 +6,12 @@ namespace Prometheus
 {
     public interface IHistogram : IObserver
     {
+        /// <summary>
+        /// observe event supporting high frequency or batch processing use cases utilizing pre-aggregation
+        /// </summary>
+        /// <param name="val">average sample value</param>
+        /// <param name="count">number of observations in a sample</param>
+        void Observe(double val, long count);
     }
 
     public sealed class Histogram : Collector<Histogram.Child>, IHistogram
@@ -96,7 +102,9 @@ namespace Prometheus
                 }
             }
 
-            public void Observe(double val)
+            public void Observe(double val) => Observe(val, 1);
+
+            public void Observe(double val, long count)
             {
                 if (double.IsNaN(val))
                 {
@@ -107,7 +115,7 @@ namespace Prometheus
                 {
                     if (val <= _upperBounds[i])
                     {
-                        _bucketCounts[i].Add(1);
+                        _bucketCounts[i].Add(count);
                         break;
                     }
                 }
@@ -118,7 +126,9 @@ namespace Prometheus
 
         internal override MetricType Type => MetricType.Histogram;
 
-        public void Observe(double val) => Unlabelled.Observe(val);
+        public void Observe(double val) => Unlabelled.Observe(val, 1);
+        
+        public void Observe(double val, long count) => Unlabelled.Observe(val, count);
 
         public void Publish() => Unlabelled.Publish();
 


### PR DESCRIPTION
Avoid distribution bias by providing (currently hard-coded to 1L) sample size in Observe method of the Histogram. 

BACKGROUND:

In high frequency or batch processing scenarios it is incorrect to account using batch level metric when batches are variable size. In high frequency scenario the cost of accounting (for-each loop instead of binary search etc) may surpass the cost of measured event by 1-2 order(s) of magnitude rending instrumentation impractical.

The simplest solution is to aggregate random sample and record it using average sample measurement and sample size. That is what this change provides.

The Summary is more complicated as it needs many more changes in buffering algorithm. It would probably be best to provide new type of Summary that correctly accounts for sample size.