### PR TITLE
Allowing specifying a port to host metrics

### DIFF
--- a/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
@@ -41,28 +41,27 @@ namespace Prometheus
                 Registry = registry
             });
         }
+    }
 
-        public class PathAndPort
+    public class PathAndPort
+    {
+        public PathAndPort(string path, int port)
         {
-            public PathAndPort(string path, int port)
-            {
-                Path = path;
-                Port = port;
-            }
-
-            /// <summary>
-            /// Creates a <see cref="PathAndPort"/> with the default URL <c>/metrics</c>, which is a Prometheus convention.
-            /// </summary>
-            /// <param name="port"></param>
-            /// <returns></returns>
-            public static PathAndPort WithDefaultPath(int port)
-            {
-                return new PathAndPort("/metrics", port);
-            }
-
-            public string Path { get; }
-            public int Port { get; }
+            Path = path;
+            Port = port;
         }
 
+        /// <summary>
+        /// Creates a <see cref="PathAndPort"/> with the default URL <c>/metrics</c>, which is a Prometheus convention.
+        /// </summary>
+        /// <param name="port"></param>
+        /// <returns></returns>
+        public static PathAndPort WithDefaultPath(int port)
+        {
+            return new PathAndPort("/metrics", port);
+        }
+
+        public string Path { get; }
+        public int Port { get; }
     }
 }

--- a/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
@@ -1,9 +1,26 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 
 namespace Prometheus
 {
     public static class MetricServerMiddlewareExtensions
     {
+        /// <summary>
+        /// Starts a Prometheus metrics exporter on a specific port.
+        /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
+        /// </summary>
+        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, PathAndPort pathAndPort, CollectorRegistry? registry = null)
+        {
+            return builder
+                .Map(pathAndPort.Path, b => b.MapWhen(PortMatches(), b1 => b1.InternalUseMiddleware(registry)));
+
+            Func<HttpContext, bool> PortMatches()
+            {
+                return c => c.Connection.LocalPort == pathAndPort.Port;
+            }
+        }
+
         /// <summary>
         /// Starts a Prometheus metrics exporter. The default URL is /metrics, which is a Prometheus convention.
         /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
@@ -12,24 +29,17 @@ namespace Prometheus
         {
             // If there is a URL to map, map it and re-enter without the URL.
             if (url != null)
-                return builder.Map(url, builder2 => builder2.UseMetricServer((string?)null, registry));
+                return builder.Map(url, b => b.InternalUseMiddleware(registry));
+            else
+                return builder.InternalUseMiddleware(registry);
+        }
 
+        private static IApplicationBuilder InternalUseMiddleware(this IApplicationBuilder builder, CollectorRegistry? registry = null)
+        {
             return builder.UseMiddleware<MetricServerMiddleware>(new MetricServerMiddleware.Settings
             {
                 Registry = registry
             });
-        }
-
-
-        /// <summary>
-        /// Starts a Prometheus metrics exporter on a specific port.
-        /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
-        /// </summary>
-        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, PathAndPort pathAndPort, CollectorRegistry? registry = null)
-        {
-            return builder.MapWhen(
-                c => c.Connection.LocalPort == pathAndPort.Port,
-                b0 => b0.Map(pathAndPort.Path, b1 => b1.UseMetricServer((string?)null, registry)));
         }
 
         public class PathAndPort
@@ -40,13 +50,19 @@ namespace Prometheus
                 Port = port;
             }
 
+            /// <summary>
+            /// Creates a <see cref="PathAndPort"/> with the default URL <c>/metrics</c>, which is a Prometheus convention.
+            /// </summary>
+            /// <param name="port"></param>
+            /// <returns></returns>
             public static PathAndPort WithDefaultPath(int port)
             {
                 return new PathAndPort("/metrics", port);
             }
 
-            public string Path { get; set; }
-            public int Port { get; set; }
+            public string Path { get; }
+            public int Port { get; }
         }
+
     }
 }

--- a/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
@@ -10,14 +10,14 @@ namespace Prometheus
         /// Starts a Prometheus metrics exporter on a specific port.
         /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
         /// </summary>
-        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, PathAndPort pathAndPort, CollectorRegistry? registry = null)
+        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, int port, string? url = "/metrics", CollectorRegistry? registry = null)
         {
             return builder
-                .Map(pathAndPort.Path, b => b.MapWhen(PortMatches(), b1 => b1.InternalUseMiddleware(registry)));
+                .Map(url, b => b.MapWhen(PortMatches(), b1 => b1.InternalUseMiddleware(registry)));
 
             Func<HttpContext, bool> PortMatches()
             {
-                return c => c.Connection.LocalPort == pathAndPort.Port;
+                return c => c.Connection.LocalPort == port;
             }
         }
 
@@ -41,27 +41,5 @@ namespace Prometheus
                 Registry = registry
             });
         }
-    }
-
-    public class PathAndPort
-    {
-        public PathAndPort(string path, int port)
-        {
-            Path = path;
-            Port = port;
-        }
-
-        /// <summary>
-        /// Creates a <see cref="PathAndPort"/> with the default URL <c>/metrics</c>, which is a Prometheus convention.
-        /// </summary>
-        /// <param name="port"></param>
-        /// <returns></returns>
-        public static PathAndPort WithDefaultPath(int port)
-        {
-            return new PathAndPort("/metrics", port);
-        }
-
-        public string Path { get; }
-        public int Port { get; }
     }
 }

--- a/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
@@ -8,11 +8,20 @@ namespace Prometheus
         /// Starts a Prometheus metrics exporter. The default URL is /metrics, which is a Prometheus convention.
         /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
         /// </summary>
-        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, string? url = "/metrics", CollectorRegistry? registry = null)
+        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, string? url = "/metrics", CollectorRegistry? registry = null, int? port)
         {
             // If there is a URL to map, map it and re-enter without the URL.
             if (url != null)
-                return builder.Map(url, builder2 => builder2.UseMetricServer(null, registry));
+            {
+                if(port.HasValue)
+                {
+                    return builder.MapWhen(
+                        c => c.Connection.LocalPort == port,
+                        b0 => b0.Map(path, b1 => b1.UseMetricServer(null, registry)));
+                }
+                else
+                    return builder.Map(url, builder2 => builder2.UseMetricServer(null, registry));
+            }
 
             return builder.UseMiddleware<MetricServerMiddleware>(new MetricServerMiddleware.Settings
             {

--- a/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
@@ -8,25 +8,45 @@ namespace Prometheus
         /// Starts a Prometheus metrics exporter. The default URL is /metrics, which is a Prometheus convention.
         /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
         /// </summary>
-        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, string? url = "/metrics", CollectorRegistry? registry = null, int? port)
+        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, string? url = "/metrics", CollectorRegistry? registry = null)
         {
             // If there is a URL to map, map it and re-enter without the URL.
             if (url != null)
-            {
-                if(port.HasValue)
-                {
-                    return builder.MapWhen(
-                        c => c.Connection.LocalPort == port,
-                        b0 => b0.Map(path, b1 => b1.UseMetricServer(null, registry)));
-                }
-                else
-                    return builder.Map(url, builder2 => builder2.UseMetricServer(null, registry));
-            }
+                return builder.Map(url, builder2 => builder2.UseMetricServer((string?)null, registry));
 
             return builder.UseMiddleware<MetricServerMiddleware>(new MetricServerMiddleware.Settings
             {
                 Registry = registry
             });
+        }
+
+
+        /// <summary>
+        /// Starts a Prometheus metrics exporter on a specific port.
+        /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
+        /// </summary>
+        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, PathAndPort pathAndPort, CollectorRegistry? registry = null)
+        {
+            return builder.MapWhen(
+                c => c.Connection.LocalPort == pathAndPort.Port,
+                b0 => b0.Map(pathAndPort.Path, b1 => b1.UseMetricServer((string?)null, registry)));
+        }
+
+        public class PathAndPort
+        {
+            public PathAndPort(string path, int port)
+            {
+                Path = path;
+                Port = port;
+            }
+
+            public static PathAndPort WithDefaultPath(int port)
+            {
+                return new PathAndPort("/metrics", port);
+            }
+
+            public string Path { get; set; }
+            public int Port { get; set; }
         }
     }
 }


### PR DESCRIPTION
For example, this allows metrics to be served only over port 5001. This way API endpoints can be exposed over 5000 (or any other port) without also exposing potentially internal metrics.

I looked at updating the existing extension method but simply adding an `int? port` at the end of the method (to avoid a breaking change by reordering parameters) but:
- the ordering of parameters with path at beginning and port at end was odd
- shoving all implementation in one method was a bit complicated to follow

I'm open to opinions on placing `PathAndPort` in a separate file if that better matches the desired repository style.