### PR TITLE
AspNetCore: Support for adding OData controller name to the HttpRequestLabelNames…

### DIFF
--- a/Prometheus.AspNetCore/HttpMetrics/HttpRequestMiddlewareBase.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpRequestMiddlewareBase.cs
@@ -56,6 +56,11 @@ namespace Prometheus.HttpMetrics
                     routeData?.Values["Action"] as string ?? string.Empty);
                 UpdateMetricValueIfExists(HttpRequestLabelNames.Controller,
                     routeData?.Values["Controller"] as string ?? string.Empty);
+                if ((routeData?.Values.ContainsKey("odataPath")).GetValueOrDefault())
+                {
+                    UpdateMetricValueIfExists(HttpRequestLabelNames.Controller,
+                        routeData?.Values["odataPath"] as string ?? string.Empty);    
+                }
             }
 
             return _labelNames.Where(_labelData.ContainsKey).Select(x => _labelData[x]).ToArray();


### PR DESCRIPTION
When using this library together with OData (https://github.com/OData/WebApi) the controller label remains empty. The OData team has decided to store the controller name using the key "odataPath" instead of "Controller".
This PR adds support for writing the OData controller name to the controller label.

Before:
![image](https://user-images.githubusercontent.com/3147748/67547784-52a33880-f700-11e9-8dd6-5aee7428c924.png)

After:
![image](https://user-images.githubusercontent.com/3147748/67547800-5d5dcd80-f700-11e9-93cc-13845e6193ce.png)
