### PR TITLE
Support for OData

### DIFF
--- a/Tests.NetCore/HttpExporter/MetricTestHelpers.cs
+++ b/Tests.NetCore/HttpExporter/MetricTestHelpers.cs
@@ -23,6 +23,22 @@ namespace Tests.HttpExporter
             };
         }
 
+        public static void SetupHttpContextOData(DefaultHttpContext hc, int expectedStatusCode, string expectedMethod,
+            string expectedAction, string expectedController, string key)
+        {
+            hc.Response.StatusCode = expectedStatusCode;
+            hc.Request.Method = expectedMethod;
+
+            expectedController = $"{expectedController}({key})";
+            hc.Features[typeof(IRoutingFeature)] = new FakeRoutingFeature
+            {
+                RouteData = new RouteData
+                {
+                    Values = { { "Action", expectedAction }, { "odataPath", expectedController }, {"Key", key} }
+                }
+            };
+        }
+
         internal static string GetLabelValueOrDefault(Labels labels, string name)
         {
             return labels.Names

--- a/Tests.NetCore/HttpExporter/RequestCountMiddlewareODataTests.cs
+++ b/Tests.NetCore/HttpExporter/RequestCountMiddlewareODataTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prometheus;
+using Prometheus.HttpMetrics;
+using System.Linq;
+using System.Threading.Tasks;
+using static Tests.HttpExporter.MetricTestHelpers;
+
+namespace Tests.HttpExporter
+{
+    [TestClass]
+    public class RequestCountMiddlewareODataTests
+    {
+        private Counter _counter;
+        private DefaultHttpContext _httpContext;
+        private RequestDelegate _requestDelegate;
+
+        private CollectorRegistry _registry;
+        private MetricFactory _factory;
+
+        private HttpRequestCountMiddleware _sut;
+
+        [DataTestMethod]
+        [DataRow("'X'")]
+        [DataRow("1")]
+        public async Task Given_request_populates_labels_correctly(string key)
+        {
+            var counter = _factory.CreateCounter("all_labels_counter", "", HttpRequestLabelNames.All);
+
+            var expectedStatusCode = 400;
+            var expectedMethod = "METHOD";
+            var expectedAction = "ACTION";
+            var expectedController = "CONTROLLER()";
+            SetupHttpContextOData(_httpContext, expectedStatusCode, expectedMethod, expectedAction, "CONTROLLER", key);
+            _sut = new HttpRequestCountMiddleware(_requestDelegate, counter);
+
+            await _sut.Invoke(_httpContext);
+
+            var labels = counter.GetAllLabels().Single();
+            Assert.AreEqual(expectedStatusCode.ToString(), GetLabelValueOrDefault(labels, HttpRequestLabelNames.Code));
+            Assert.AreEqual(expectedMethod, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Method));
+            Assert.AreEqual(expectedAction, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Action));
+            Assert.AreEqual(expectedController, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Controller));
+        }
+
+        [DataTestMethod]
+        [DataRow("'X'")]
+        [DataRow("1")]
+        public async Task Given_multiple_requests_populates_controller_label_correctly(string key)
+        {
+            var counter = _factory.CreateCounter("counter", "", HttpRequestLabelNames.Controller);
+            _sut = new HttpRequestCountMiddleware(_requestDelegate, counter);
+
+            var expectedController1 = await SetControllerAndInvoke("ValuesController", key);
+            var expectedController2 = await SetControllerAndInvoke("AuthController", key);
+
+            var labels = counter.GetAllLabels();
+            var controllers = GetLabelValues(labels, HttpRequestLabelNames.Controller);
+
+            Assert.AreEqual(2, controllers.Length);
+            CollectionAssert.AreEquivalent(new[] { expectedController1, expectedController2 }, controllers);
+        }
+
+        [TestMethod]
+        public async Task Given_multiple_requests_populates_controller_label_correctly_no_key()
+        {
+            var counter = _factory.CreateCounter("counter", "", HttpRequestLabelNames.Controller);
+            _sut = new HttpRequestCountMiddleware(_requestDelegate, counter);
+
+            var expectedController1 = await SetControllerAndInvoke("ValuesController()");
+            var expectedController2 = await SetControllerAndInvoke("AuthController()");
+
+            var labels = counter.GetAllLabels();
+            var controllers = GetLabelValues(labels, HttpRequestLabelNames.Controller);
+
+            Assert.AreEqual(2, controllers.Length);
+            CollectionAssert.AreEquivalent(new[] { expectedController1, expectedController2 }, controllers);
+        }
+
+        [DataTestMethod]
+        [DataRow("'X'")]
+        [DataRow("1")]
+        public async Task Given_request_populates_subset_of_labels_correctly(string key)
+        {
+            var counter = _factory.CreateCounter("all_labels_counter", "", HttpRequestLabelNames.Action,
+                HttpRequestLabelNames.Controller);
+
+            var expectedAction = "ACTION";
+            var expectedController = "CONTROLLER()";
+            SetupHttpContextOData(_httpContext, 200, "method", expectedAction, "CONTROLLER", key);
+            _sut = new HttpRequestCountMiddleware(_requestDelegate, counter);
+
+            await _sut.Invoke(_httpContext);
+
+            var labels = counter.GetAllLabels().Single();
+            Assert.IsNull(GetLabelValueOrDefault(labels, HttpRequestLabelNames.Code));
+            Assert.IsNull(GetLabelValueOrDefault(labels, HttpRequestLabelNames.Method));
+            Assert.AreEqual(expectedAction, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Action));
+            Assert.AreEqual(expectedController, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Controller));
+        }
+
+        [TestInitialize]
+        public void Init()
+        {
+            _registry = Metrics.NewCustomRegistry();
+            _factory = Metrics.WithCustomRegistry(_registry);
+            _counter = _factory.CreateCounter("default_counter", "");
+            _requestDelegate = context => Task.CompletedTask;
+
+            _httpContext = new DefaultHttpContext();
+
+            _sut = new HttpRequestCountMiddleware(_requestDelegate, _counter);
+        }
+
+        private async Task<string> SetControllerAndInvoke(string expectedController, string key)
+        {
+            _httpContext.Features[typeof(IRoutingFeature)] = new FakeRoutingFeature
+            {
+                RouteData = new RouteData
+                {
+                    Values = { { "odataPath", $"{expectedController}({key})" }, { "Key", key } }
+                }
+            };
+            await _sut.Invoke(_httpContext);
+            return $"{expectedController}()";
+        }
+
+        private async Task<string> SetControllerAndInvoke(string expectedController)
+        {
+            _httpContext.Features[typeof(IRoutingFeature)] = new FakeRoutingFeature
+            {
+                RouteData = new RouteData
+                {
+                    Values = { { "odataPath", expectedController } }
+                }
+            };
+            await _sut.Invoke(_httpContext);
+            return expectedController;
+        }
+    }
+}

--- a/Tests.NetCore/HttpExporter/RequestDurationMiddlewareODataTest.cs
+++ b/Tests.NetCore/HttpExporter/RequestDurationMiddlewareODataTest.cs
@@ -1,0 +1,240 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Prometheus;
+using Prometheus.HttpMetrics;
+using System.Linq;
+using System.Threading.Tasks;
+using static Tests.HttpExporter.MetricTestHelpers;
+
+namespace Tests.HttpExporter
+{
+    [TestClass]
+    public class RequestDurationMiddlewareODataTest
+    {
+        private Histogram _histogram;
+        private DefaultHttpContext _httpContext;
+        private RequestDelegate _requestDelegate;
+
+        private CollectorRegistry _registry;
+        private MetricFactory _factory;
+
+        private HttpRequestDurationMiddleware _sut;
+
+
+        [DataTestMethod]
+        [DataRow("'X'")]
+        [DataRow("1")]
+        public async Task Given_request_populates_labels_correctly(string key)
+        {
+            var histogram = _factory.CreateHistogram("all_labels_histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 1d, 2d, 3d },
+                LabelNames = HttpRequestLabelNames.All
+            });
+
+            var expectedStatusCode = 400;
+            var expectedMethod = "METHOD";
+            var expectedAction = "ACTION";
+            var expectedController = "CONTROLLER()";
+            SetupHttpContextOData(_httpContext, expectedStatusCode, expectedMethod, expectedAction, "CONTROLLER", key);
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, histogram);
+
+            await _sut.Invoke(_httpContext);
+
+            var labels = histogram.GetAllLabels().Single();
+            Assert.AreEqual(expectedStatusCode.ToString(), GetLabelValueOrDefault(labels, HttpRequestLabelNames.Code));
+            Assert.AreEqual(expectedMethod, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Method));
+            Assert.AreEqual(expectedAction, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Action));
+            Assert.AreEqual(expectedController, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Controller));
+        }
+
+        [DataTestMethod]
+        [DataRow("'X'")]
+        [DataRow("1")]
+        public async Task Given_request_populates_labels_supplied_out_of_order_correctly(string key)
+        {
+            var histogram = _factory.CreateHistogram("all_labels_histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 1d, 2d, 3d },
+                LabelNames = HttpRequestLabelNames.All.Reverse().ToArray()
+            });
+
+            var expectedStatusCode = 400;
+            var expectedMethod = "METHOD";
+            var expectedAction = "ACTION";
+            var expectedController = "CONTROLLER()";
+            SetupHttpContextOData(_httpContext, expectedStatusCode, expectedMethod, expectedAction, "CONTROLLER", key);
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, histogram);
+
+            await _sut.Invoke(_httpContext);
+
+            var labels = histogram.GetAllLabels().Single();
+            Assert.AreEqual(expectedStatusCode.ToString(), GetLabelValueOrDefault(labels, HttpRequestLabelNames.Code));
+            Assert.AreEqual(expectedMethod, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Method));
+            Assert.AreEqual(expectedAction, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Action));
+            Assert.AreEqual(expectedController, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Controller));
+        }
+
+        [DataTestMethod]
+        [DataRow("'X'")]
+        [DataRow("1")]
+        public async Task Given_request_populates_subset_of_labels_correctly(string key)
+        {
+            var histogram = _factory.CreateHistogram("all_labels_histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 1d, 2d, 3d },
+                LabelNames = new[] { HttpRequestLabelNames.Action, HttpRequestLabelNames.Controller }
+            });
+
+            var expectedAction = "ACTION";
+            var expectedController = "CONTROLLER()";
+            SetupHttpContextOData(_httpContext, 200, "method", expectedAction, "CONTROLLER", key);
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, histogram);
+
+            await _sut.Invoke(_httpContext);
+
+            var labels = histogram.GetAllLabels().Single();
+            Assert.IsNull(GetLabelValueOrDefault(labels, HttpRequestLabelNames.Code));
+            Assert.IsNull(GetLabelValueOrDefault(labels, HttpRequestLabelNames.Method));
+            Assert.AreEqual(expectedAction, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Action));
+            Assert.AreEqual(expectedController, GetLabelValueOrDefault(labels, HttpRequestLabelNames.Controller));
+        }
+
+
+        [DataTestMethod]
+        [DataRow("'X'")]
+        [DataRow("1")]
+        public async Task Given_multiple_requests_populates_controller_label_correctly(string key)
+        {
+            var histogram = _factory.CreateHistogram("histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 0.1d, 1d, 10d },
+                LabelNames = new[] { HttpRequestLabelNames.Controller }
+            });
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, histogram);
+
+            var expectedController1 = await SetControllerAndInvoke("ValuesController", key);
+            var expectedController2 = await SetControllerAndInvoke("AuthController", key);
+
+            var labels = histogram.GetAllLabels();
+            var controllers = GetLabelValues(labels, HttpRequestLabelNames.Controller);
+
+            Assert.AreEqual(2, controllers.Length);
+            CollectionAssert.AreEquivalent(new[] { expectedController1, expectedController2 }, controllers);
+        }
+
+        [TestMethod]
+        public async Task Given_multiple_requests_populates_controller_label_correctly_parameter()
+        {
+            var histogram = _factory.CreateHistogram("histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 0.1d, 1d, 10d },
+                LabelNames = new[] { HttpRequestLabelNames.Controller }
+            });
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, histogram);
+
+            await SetControllerAndInvoke(new RouteData
+            {
+                Values = { { "odataPath", "AuthController(ItemKey='X')" }, { "ItemKey", "X" } }
+            });
+
+            var labels = histogram.GetAllLabels();
+            var controllers = GetLabelValues(labels, HttpRequestLabelNames.Controller);
+            
+            CollectionAssert.AreEquivalent(new[] { "AuthController(ItemKey=)" }, controllers);
+        }
+
+        [TestMethod]
+        public async Task Given_multiple_requests_populates_controller_label_correctly_parameter_number()
+        {
+            var histogram = _factory.CreateHistogram("histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 0.1d, 1d, 10d },
+                LabelNames = new[] { HttpRequestLabelNames.Controller }
+            });
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, histogram);
+
+            await SetControllerAndInvoke(new RouteData
+            {
+                Values = {{"odataPath", "AuthController(Number=1)"}, {"Number", "1"}}
+            });
+            
+            var labels = histogram.GetAllLabels();
+            var controllers = GetLabelValues(labels, HttpRequestLabelNames.Controller);
+            
+            CollectionAssert.AreEquivalent(new[] { "AuthController(Number=)" }, controllers);
+        }
+
+        [TestMethod]
+        public async Task Given_multiple_requests_populates_controller_label_correctly_no_key()
+        {
+            var histogram = _factory.CreateHistogram("histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 0.1d, 1d, 10d },
+                LabelNames = new[] { HttpRequestLabelNames.Controller }
+            });
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, histogram);
+
+            var expectedController1 = await SetControllerAndInvoke("ValuesController");
+            var expectedController2 = await SetControllerAndInvoke("AuthController");
+
+            var labels = histogram.GetAllLabels();
+            var controllers = GetLabelValues(labels, HttpRequestLabelNames.Controller);
+
+            Assert.AreEqual(2, controllers.Length);
+            CollectionAssert.AreEquivalent(new[] { expectedController1, expectedController2 }, controllers);
+        }
+
+
+        [TestInitialize]
+        public void Init()
+        {
+            _registry = Metrics.NewCustomRegistry();
+            _factory = Metrics.WithCustomRegistry(_registry);
+
+            _histogram = _factory.CreateHistogram("default_histogram", "", new HistogramConfiguration
+            {
+                Buckets = new[] { 0.1d, 1d, 10d }
+            });
+            _requestDelegate = context => Task.CompletedTask;
+            _httpContext = new DefaultHttpContext();
+            _sut = new HttpRequestDurationMiddleware(_requestDelegate, _histogram);
+        }
+
+        private async Task<string> SetControllerAndInvoke(string expectedController)
+        {
+            _httpContext.Features[typeof(IRoutingFeature)] = new FakeRoutingFeature
+            {
+                RouteData = new RouteData
+                {
+                    Values = { { "odataPath", expectedController } }
+                }
+            };
+            await _sut.Invoke(_httpContext);
+            return expectedController;
+        }
+
+        private async Task<string> SetControllerAndInvoke(string expectedController, string key)
+        {
+            _httpContext.Features[typeof(IRoutingFeature)] = new FakeRoutingFeature
+            {
+                RouteData = new RouteData
+                {
+                    Values = { { "odataPath", $"{expectedController}({key})" }, { "Key", key } }
+                }
+            };
+            await _sut.Invoke(_httpContext);
+            return $"{expectedController}()";
+        }
+
+        private async Task SetControllerAndInvoke(RouteData routeData)
+        {
+            _httpContext.Features[typeof(IRoutingFeature)] = new FakeRoutingFeature
+            {
+                RouteData = routeData
+            };
+            await _sut.Invoke(_httpContext);
+        }
+    }
+}


### PR DESCRIPTION
When using this library together with OData (https://github.com/OData/WebApi) the controller label remains empty. The OData team has decided to store the controller name using the key "odataPath" instead of "Controller". 
This PR adds support for writing the OData controller name to the controller label.

Before:
![image](https://user-images.githubusercontent.com/3147748/67662782-6353e880-f964-11e9-9c02-9d809f146655.png)

After:
![image](https://user-images.githubusercontent.com/3147748/67662791-67800600-f964-11e9-8539-030940b00e72.png)
