### PR TITLE
Add dependency for System.ValueTuple on .NET 4.6.1

### DIFF
--- a/Resources/Nuspec/prometheus-net.nuspec
+++ b/Resources/Nuspec/prometheus-net.nuspec
@@ -15,6 +15,9 @@
     <releaseNotes></releaseNotes>
 
     <dependencies>
+      <group targetFramework="net461">
+        <dependency id="System.ValueTuple" version="4.5.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
In my previous .NET 4.6.1 PR #157, I added a PackageReference to System.ValueTuple as required for pre-4.7 builds but didn't add the appropriate dependency to the `.nuspec`, which lead to [this error](https://github.com/prometheus-net/prometheus-net/issues/155#issuecomment-560347625):

```
System.TypeInitializationException: The type initializer for 'Prometheus.Metrics' threw an exception. ---> System.IO.FileNotFoundException: Could not load file or assembly 'System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.
```

The workaround is to simply add the NuGet package reference yourself, but this dependency should fix it without having to manually add the reference.