### PR TITLE
better use of concurrency in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ The following is a minimal implementation that simply increments a counter once 
 ```csharp
 using Prometheus;
 using System;
-using System.Threading;
+using System.Threading.Tasks;
 
 class Program
 {
     private static readonly Counter TickTock =
         Metrics.CreateCounter("sampleapp_ticks_total", "Just keeps on ticking");
 
-    static void Main()
+    static async Task Main()
     {
         var server = new MetricServer(hostname: "localhost", port: 1234);
         server.Start();
@@ -97,7 +97,7 @@ class Program
         while (true)
         {
             TickTock.Inc();
-            Thread.Sleep(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(1));
         }
     }
 }


### PR DESCRIPTION
It doesn't matter so much in this specific example, but `Thread.Sleep` is generally considered deprecated in favor of `Task.Delay` in concurrent applications.