### PR TITLE
Use the connection's cancellation token

### DIFF
--- a/Prometheus.AspNetCore/MetricServerMiddleware.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddleware.cs
@@ -38,7 +38,7 @@ namespace Prometheus
                     return response.Body;
                 });
 
-                await _registry.CollectAndSerializeAsync(serializer, default);
+                await _registry.CollectAndSerializeAsync(serializer, context.RequestAborted);
             }
             catch (ScrapeFailedException ex)
             {


### PR DESCRIPTION
When the request's connection is aborted, so should all operations.