### PR TITLE
Set thread names

### DIFF
--- a/Prometheus.NetStandard/MetricServer.cs
+++ b/Prometheus.NetStandard/MetricServer.cs
@@ -35,6 +35,7 @@ namespace Prometheus
             {
                 try
                 {
+                    Thread.CurrentThread.Name = "Metric Server";     //Max length 16 chars (Linux limitation)
                     while (!cancel.IsCancellationRequested)
                     {
                         // There is no way to give a CancellationToken to GCA() so, we need to hack around it a bit.
@@ -50,6 +51,7 @@ namespace Prometheus
 
                               try
                               {
+                                  Thread.CurrentThread.Name = "Metric Process";
                                   try
                                   {
                                       // We first touch the response.OutputStream only in the callback because touching
@@ -82,7 +84,7 @@ namespace Prometheus
                                   if (!_httpListener.IsListening)
                                       return; // We were shut down.
 
-                                  Trace.WriteLine(string.Format("Error in MetricsServer: {0}", ex));
+                                  Trace.WriteLine(string.Format("Error in {0}: {1}", nameof(MetricServer), ex));
 
                                   try
                                   {


### PR DESCRIPTION
(.NET 5 Preview 1)
Using `htop` on Linux, and switching to tree view & enabling custom thread names will show you all the child thread names:

![image](https://user-images.githubusercontent.com/1031306/78163916-e7912700-7440-11ea-8a8f-550cb8aeb556.png)

This pull request will show `Metric Listener` and `Metric Process` as child thread names.