### PR TITLE
AspNetCore HealthCheckPublisher Added with IServiceCollection extension

### DIFF
--- a/Prometheus.AspNetCore/HealthChecks/HealthCheckBuilderExtensions.cs
+++ b/Prometheus.AspNetCore/HealthChecks/HealthCheckBuilderExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Prometheus.HealthChecks
+{
+    public static class HealthCheckBuilderExtensions
+    {
+        public static IHealthChecksBuilder ForwardToPrometheus(this IHealthChecksBuilder builder)
+        {
+            builder.Services.AddSingleton<IHealthCheckPublisher, HealthCheckPublisher>();
+
+            return builder;
+        }
+    }
+}

--- a/Prometheus.AspNetCore/HealthChecks/HealthCheckPublisher.cs
+++ b/Prometheus.AspNetCore/HealthChecks/HealthCheckPublisher.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Prometheus.HealthChecks
+{
+    internal sealed class HealthCheckPublisher : IHealthCheckPublisher
+    {
+        private const string HEALTH_CHECK_LABEL = "hc";
+
+        private readonly Gauge _healthCheckGaugeMetric;
+
+        public HealthCheckPublisher()
+        {
+            _healthCheckGaugeMetric = Metrics.CreateGauge("healthcheck",
+                "AspNetCore.Diagnostics.HealthChecks # 0={Unhealthy}, 1={Degraded}, 2={Healthy}", new GaugeConfiguration
+                {
+                    LabelNames = new string[] { HEALTH_CHECK_LABEL }
+                });
+        }
+
+        private async Task SendHealthReportMetrics(HealthReport report)
+        {
+            await Task.Run(() =>
+            {
+                foreach (var reportEntry in report.Entries)
+                    _healthCheckGaugeMetric.Labels(reportEntry.Key).
+                        Set((double)reportEntry.Value.Status);
+            });
+
+        }
+        public async Task PublishAsync(HealthReport report, CancellationToken cancellationToken) => await SendHealthReportMetrics(report);
+
+    }
+}

--- a/Prometheus.AspNetCore/Prometheus.AspNetCore.csproj
+++ b/Prometheus.AspNetCore/Prometheus.AspNetCore.csproj
@@ -41,6 +41,11 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.3" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\Prometheus.NetStandard\Prometheus.NetStandard.csproj" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Related projects:
 * [When are metrics published?](#when-are-metrics-published)
 * [ASP.NET Core exporter middleware](#aspnet-core-exporter-middleware)
 * [ASP.NET Core HTTP request metrics](#aspnet-core-http-request-metrics)
+* [ASP.NET Core HealthChecks](#aspnet-core-healthChecks)
 * [ASP.NET Core with basic authentication](#aspnet-core-with-basic-authentication)
 * [ASP.NET Web API exporter](#aspnet-web-api-exporter)
 * [Kestrel stand-alone server](#kestrel-stand-alone-server)
@@ -325,7 +326,7 @@ public void Configure(IApplicationBuilder app, ...)
     // ASP.NET Core 2
     app.UseMetricServer();
 
-    // ...
+    // ...#aspnet-core-http-request-metrics
 
     // ASP.NET Core 3 or newer
     app.UseEndpoints(endpoints =>
@@ -375,6 +376,33 @@ public void Configure(IApplicationBuilder app, ...)
 ```
 
 NB! Exception handler middleware that changes HTTP response codes must be registered **after** `UseHttpMetrics()` in order to ensure that prometheus-net reports the correct HTTP response status code.
+
+# ASP.NET Core HealthChecks
+
+The library exposes any metrics from ASP.NET Core applications via Microsoft.Extensions.Diagnostics.HealthChecks:
+
+These metrics include labels for healthCheckEntry Key and healthCheckEntry Status which can be (0={Unhealthy}, 1={Degraded}, 2={Healthy})
+
+The ASP.NET Core functionality is delivered in the `prometheus-net.AspNetCore` NuGet package.
+
+You can expose HTTP metrics by fluently extending your IHealthChecksBuilder `Startup.ConfigureServices()` method:
+
+Example `Startup.cs` :
+
+```csharp
+public void ConfigureServices(IServiceCollection services, ...)
+{
+    // ...
+
+    services.AddHealthChecks()
+             // ...
+             <Your Health Checks>
+             // ...
+             .ForwardToPrometheus();
+
+    // ...
+}
+```
 
 # ASP.NET Core with basic authentication
 


### PR DESCRIPTION
Hi Sander,

I was thinking that Gauge metrics can be used for Microsoft.Extensions.Diagnostics.HealthChecks as an extensions. For that purpose, I'm creating pull request for AspNetCore HealthChecks inludes with README.md file changes.