### PR TITLE
Reducing metricpussher allocations

### DIFF
--- a/Benchmark.NetCore/MetricPusherBenchmarks.cs
+++ b/Benchmark.NetCore/MetricPusherBenchmarks.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Prometheus;
+
+namespace Benchmark.NetCore
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RunStrategy.Monitoring, warmupCount:0)]
+    public class MetricPusherBenchmarks
+    {
+        [Benchmark]
+        public async Task PushTest()
+        {
+            var registry = Metrics.NewCustomRegistry();
+            var factory = Metrics.WithCustomRegistry(registry);
+            
+            var pusher = new MetricPusher(new MetricPusherOptions
+            {
+                Endpoint = "http://127.0.0.1:9091/metrics",
+                Registry = registry,
+                IntervalMilliseconds = 30,
+                Job = "job"
+            });
+            pusher.Start();
+
+            var counters = new List<Counter>();
+            for (int i = 0; i < 1000; i++)
+            {
+                var counter = factory.CreateCounter($"Counter{i}", String.Empty);
+                counters.Add(counter);
+            }
+
+            var ct = new CancellationTokenSource();
+            var incTask = Task.Run(async () =>
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    foreach (var counter in counters)
+                    {
+                        counter.Inc();
+                    }
+
+                    await Task.Delay(30);
+                }
+            });
+
+            await Task.Delay(5000);
+            ct.Cancel();
+            await incTask;
+
+            pusher.Stop();
+        }
+    }
+}

--- a/Benchmark.NetCore/Program.cs
+++ b/Benchmark.NetCore/Program.cs
@@ -11,6 +11,7 @@ namespace Benchmark.NetCore
             //BenchmarkRunner.Run<LabelBenchmarks>();
             //BenchmarkRunner.Run<HttpExporterBenchmarks>();
             BenchmarkRunner.Run<SummaryBenchmarks>();
+            // BenchmarkRunner.Run<MetricPusherBenchmarks>();
         }
     }
 }

--- a/Prometheus.NetStandard/MetricPusher.cs
+++ b/Prometheus.NetStandard/MetricPusher.cs
@@ -18,7 +18,7 @@ namespace Prometheus
         private readonly TimeSpan _pushInterval;
         private readonly Uri _targetUrl;
         private readonly Func<HttpClient> _httpClientProvider;
-        private readonly RecyclableMemoryStreamManager? _memoryStreamManager;
+        private readonly RecyclableMemoryStreamManager _memoryStreamManager;
 
         public MetricPusher(string endpoint, string job, string? instance = null, long intervalMilliseconds = 1000, IEnumerable<Tuple<string, string>>? additionalLabels = null, CollectorRegistry? registry = null,
             RecyclableMemoryStreamManager? memoryStreamManager = null) 

--- a/Prometheus.NetStandard/MetricPusherOptions.cs
+++ b/Prometheus.NetStandard/MetricPusherOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Microsoft.IO;
 
 namespace Prometheus
 {
@@ -14,6 +15,7 @@ namespace Prometheus
         public long IntervalMilliseconds { get; set; } = 1000;
         public IEnumerable<Tuple<string, string>>? AdditionalLabels { get; set; }
         public CollectorRegistry? Registry { get; set; }
+        public RecyclableMemoryStreamManager? MemoryStreamManager { get; set; }
 
         /// <summary>
         /// If null, a singleton HttpClient will be used.

--- a/Prometheus.NetStandard/Prometheus.NetStandard.csproj
+++ b/Prometheus.NetStandard/Prometheus.NetStandard.csproj
@@ -29,4 +29,8 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.3" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
I found out that MetricPusher wasted memory because he created new MemoryStream for every push.
In this PR I use RecyclablememoryStream https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream
 Benchmark result
Before 
![image](https://user-images.githubusercontent.com/7288803/80197306-22910f80-8627-11ea-8531-f4358fe01225.png)
After 
![image](https://user-images.githubusercontent.com/7288803/80197341-2ae94a80-8627-11ea-85ea-26c064f55194.png)
The benchamrk in MetricPusherBenchmarks.cs