### PR TITLE
Add gRPC request duration histogram

### DIFF
--- a/Benchmark.NetCore/Benchmark.NetCore.csproj
+++ b/Benchmark.NetCore/Benchmark.NetCore.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Prometheus.AspNetCore.Grpc\Prometheus.AspNetCore.Grpc.csproj" />
     <ProjectReference Include="..\Prometheus.AspNetCore\Prometheus.AspNetCore.csproj" />
     <ProjectReference Include="..\Prometheus.NetStandard\Prometheus.NetStandard.csproj" />
   </ItemGroup>

--- a/Benchmark.NetCore/GrpcExporterBenchmarks.cs
+++ b/Benchmark.NetCore/GrpcExporterBenchmarks.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using Prometheus;
+using System.Threading.Tasks;
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+
+namespace Benchmark.NetCore
+{
+    [MemoryDiagnoser]
+    public class GrpcExporterBenchmarks
+    {
+        private CollectorRegistry _registry;
+        private MetricFactory _factory;
+        private GrpcRequestCountMiddleware _countMiddleware;
+        private GrpcRequestDurationMiddleware _durationMiddleware;
+        private DefaultHttpContext _ctx;
+
+        [Params(1000, 10000)]
+        public int RequestCount { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _ctx = new DefaultHttpContext();
+            _ctx.SetEndpoint(new Endpoint(
+                ctx => Task.CompletedTask, 
+                new EndpointMetadataCollection(new GrpcMethodMetadata(typeof(int),
+                    new Method<object, object>(MethodType.Unary,
+                        "test",
+                        "test",
+                        new Marshaller<object>(o => new byte[0], c => null), 
+                        new Marshaller<object>(o => new byte[0], c => null)))),
+                "test"));
+            _registry = Metrics.NewCustomRegistry();
+            _factory = Metrics.WithCustomRegistry(_registry);
+
+            _countMiddleware = new GrpcRequestCountMiddleware(next => Task.CompletedTask, new GrpcRequestCountOptions
+            {
+                Counter = _factory.CreateCounter("count", "help")
+            });
+            _durationMiddleware = new GrpcRequestDurationMiddleware(next => Task.CompletedTask, new GrpcRequestDurationOptions
+            {
+                Histogram = _factory.CreateHistogram("duration", "help")
+            });
+        }
+
+        [Benchmark]
+        public async Task GrpcRequestCount()
+        {
+            for (var i = 0; i < RequestCount; i++)
+                await _countMiddleware.Invoke(_ctx);
+        }
+
+        [Benchmark]
+        public async Task GrpcRequestDuration()
+        {
+            for (var i = 0; i < RequestCount; i++)
+                await _durationMiddleware.Invoke(_ctx);
+        }
+    }
+}

--- a/Benchmark.NetCore/Program.cs
+++ b/Benchmark.NetCore/Program.cs
@@ -11,7 +11,8 @@ namespace Benchmark.NetCore
             //BenchmarkRunner.Run<LabelBenchmarks>();
             //BenchmarkRunner.Run<HttpExporterBenchmarks>();
             //BenchmarkRunner.Run<SummaryBenchmarks>();
-            BenchmarkRunner.Run<MetricPusherBenchmarks>();
+            //BenchmarkRunner.Run<MetricPusherBenchmarks>();
+            BenchmarkRunner.Run<GrpcExporterBenchmarks>();
         }
     }
 }

--- a/Prometheus.AspNetCore.Grpc/GrpcMetricsMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore.Grpc/GrpcMetricsMiddlewareExtensions.cs
@@ -30,6 +30,11 @@ namespace Prometheus
                 app.UseMiddleware<GrpcRequestCountMiddleware>(options.RequestCount);
             }
 
+            if (options.RequestDuration.Enabled)
+            {
+                app.UseMiddleware<GrpcRequestDurationMiddleware>(options.RequestDuration);
+            }
+
             return app;
         }
     }

--- a/Prometheus.AspNetCore.Grpc/GrpcMiddlewareExporterOptions.cs
+++ b/Prometheus.AspNetCore.Grpc/GrpcMiddlewareExporterOptions.cs
@@ -3,5 +3,7 @@
     public sealed class GrpcMiddlewareExporterOptions
     {
         public GrpcRequestCountOptions RequestCount { get; set; } = new GrpcRequestCountOptions();
+        
+        public GrpcRequestDurationOptions RequestDuration { get; set; } = new GrpcRequestDurationOptions();
     }
 }

--- a/Prometheus.AspNetCore.Grpc/GrpcRequestDurationMiddleware.cs
+++ b/Prometheus.AspNetCore.Grpc/GrpcRequestDurationMiddleware.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Prometheus.HttpMetrics;
+
+namespace Prometheus
+{
+    internal sealed class GrpcRequestDurationMiddleware : GrpcRequestMiddlewareBase<ICollector<IHistogram>, IHistogram>
+    {
+        private readonly RequestDelegate _next;
+
+        public GrpcRequestDurationMiddleware(RequestDelegate next, GrpcRequestDurationOptions? options)
+            : base(options, options?.Histogram)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            var stopWatch = Stopwatch.StartNew();
+
+            // We need to write this out in long form instead of using a timer because routing data in
+            // ASP.NET Core 2 is only available *after* executing the next request delegate.
+            // So we would not have the right labels if we tried to create the child early on.
+            try
+            {
+                await _next(context);
+            }
+            finally
+            {
+                stopWatch.Stop();
+
+                CreateChild(context)?.Observe(stopWatch.Elapsed.TotalSeconds);
+            }
+        }
+
+        protected override string[] DefaultLabels => GrpcRequestLabelNames.NoStatusSpecific;
+
+        protected override ICollector<IHistogram> CreateMetricInstance(string[] labelNames) => MetricFactory.CreateHistogram(
+            "grpc_request_duration_seconds",
+            "The duration of gRPC requests processed by an ASP.NET Core application.",
+            new HistogramConfiguration
+            {
+                // 1 ms to 32K ms buckets
+                Buckets = Histogram.ExponentialBuckets(0.001, 2, 16),
+                LabelNames = labelNames
+            });
+    }
+}

--- a/Prometheus.AspNetCore.Grpc/GrpcRequestDurationOptions.cs
+++ b/Prometheus.AspNetCore.Grpc/GrpcRequestDurationOptions.cs
@@ -1,0 +1,10 @@
+namespace Prometheus
+{
+    public sealed class GrpcRequestDurationOptions : GrpcMetricsOptionsBase
+    {
+        /// <summary>
+        /// Set this to use a custom metric instead of the default.
+        /// </summary>
+        public ICollector<IHistogram>? Histogram { get; set; }
+    }
+}

--- a/Prometheus.AspNetCore.Grpc/GrpcRequestLabelNames.cs
+++ b/Prometheus.AspNetCore.Grpc/GrpcRequestLabelNames.cs
@@ -7,8 +7,16 @@
     {
         public const string Service = "service";
         public const string Method = "method";
+        public const string Status = "status";
 
         public static readonly string[] All =
+        {
+            Service,
+            Method,
+            Status,
+        };
+        
+        public static readonly string[] NoStatusSpecific =
         {
             Service,
             Method,

--- a/Prometheus.AspNetCore.Grpc/GrpcRequestMiddlewareBase.cs
+++ b/Prometheus.AspNetCore.Grpc/GrpcRequestMiddlewareBase.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Http;
 using System;
 using System.Linq;
+using System.Threading;
 using Grpc.AspNetCore.Server;
+using Grpc.Core;
 
 namespace Prometheus
 {
@@ -78,6 +80,10 @@ namespace Prometheus
                     case GrpcRequestLabelNames.Method:
                         labelValues[i] = metadata.Method.Name;
                         break;
+                    case GrpcRequestLabelNames.Status:
+                        labelValues[i] =  context.Response?.GetStatusCode().ToString() ?? StatusCode.OK.ToString();
+                        break;
+                    
                     default:
                         // Should never reach this point because we validate in ctor.
                         throw new NotSupportedException($"Unexpected label name on {_metric.Name}: {_metric.LabelNames[i]}");

--- a/Prometheus.AspNetCore.Grpc/HttpResponseExtensions.cs
+++ b/Prometheus.AspNetCore.Grpc/HttpResponseExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using Grpc.Core;
+using Microsoft.AspNetCore.Http;
+
+namespace Prometheus
+{
+    internal static class HttpResponseExtensions
+    {
+        private const string _grpcStatus = "grpc-status";
+
+        public static StatusCode GetStatusCode(this HttpResponse response)
+        {
+            var headerExists = response.Headers.TryGetValue(_grpcStatus, out var header);
+
+            if (!headerExists && response.StatusCode == StatusCodes.Status200OK)
+            {
+                return StatusCode.OK;
+            }
+
+            if (header.Any() && int.TryParse(header.FirstOrDefault(), out var status))
+            {
+                return (StatusCode)status;
+            }
+
+            return StatusCode.OK;
+        }
+    }
+}


### PR DESCRIPTION
I think, it would be nice to have duration histogram for grpc request just like for http requests. Unfortunately, `HttpRequestDurationMiddleware` can't be used, because it know nothing about gRPC method name. So I add `GrpcRequestDurationMiddleware` and all infrastructure for it 