### PR TITLE
Ignore http metrics by condition

### DIFF
--- a/Benchmark.NetCore/HttpExporterBenchmarks.cs
+++ b/Benchmark.NetCore/HttpExporterBenchmarks.cs
@@ -14,6 +14,7 @@ namespace Benchmark.NetCore
         private HttpInProgressMiddleware _inProgressMiddleware;
         private HttpRequestCountMiddleware _countMiddleware;
         private HttpRequestDurationMiddleware _durationMiddleware;
+        private DefaultHttpContext _ctx;
 
         [Params(1000, 10000)]
         public int RequestCount { get; set; }
@@ -23,6 +24,7 @@ namespace Benchmark.NetCore
         {
             _registry = Metrics.NewCustomRegistry();
             _factory = Metrics.WithCustomRegistry(_registry);
+            _ctx = new DefaultHttpContext();
 
             _inProgressMiddleware = new HttpInProgressMiddleware(next => Task.CompletedTask, new HttpInProgressOptions
             {
@@ -41,22 +43,22 @@ namespace Benchmark.NetCore
         [Benchmark]
         public async Task HttpInProgress()
         {
-            for (var i = 0; i < RequestCount; i++)
-                await _inProgressMiddleware.Invoke(new DefaultHttpContext());
+            for (var i = 0; i < RequestCount; i++) 
+                await _inProgressMiddleware.Invoke(_ctx);
         }
 
         [Benchmark]
         public async Task HttpRequestCount()
         {
             for (var i = 0; i < RequestCount; i++)
-                await _countMiddleware.Invoke(new DefaultHttpContext());
+                await _countMiddleware.Invoke(_ctx);
         }
 
         [Benchmark]
         public async Task HttpRequestDuration()
         {
             for (var i = 0; i < RequestCount; i++)
-                await _durationMiddleware.Invoke(new DefaultHttpContext());
+                await _durationMiddleware.Invoke(_ctx);
         }
     }
 }

--- a/Benchmark.NetCore/Program.cs
+++ b/Benchmark.NetCore/Program.cs
@@ -9,9 +9,9 @@ namespace Benchmark.NetCore
             //BenchmarkRunner.Run<MetricCreationBenchmarks>();
             //BenchmarkRunner.Run<SerializationBenchmarks>();
             //BenchmarkRunner.Run<LabelBenchmarks>();
-            //BenchmarkRunner.Run<HttpExporterBenchmarks>();
+            BenchmarkRunner.Run<HttpExporterBenchmarks>();
             //BenchmarkRunner.Run<SummaryBenchmarks>();
-            BenchmarkRunner.Run<MetricPusherBenchmarks>();
+            //BenchmarkRunner.Run<MetricPusherBenchmarks>();
         }
     }
 }

--- a/Prometheus.AspNetCore/HttpMetrics/HttpInProgressMiddleware.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpInProgressMiddleware.cs
@@ -19,7 +19,7 @@ namespace Prometheus.HttpMetrics
             // In ASP.NET Core 2, we will not have route data, so we cannot record controller/action labels.
             // In ASP.NET Core 3, we will have this data and can record the labels.
             // CreateChild() will take care of applying the right labels, no need to think hard about it here.
-            using (CreateChild(context).TrackInProgress())
+            using (CreateChild(context)?.TrackInProgress())
             {
                 await _next(context);
             }

--- a/Prometheus.AspNetCore/HttpMetrics/HttpMetricsOptionsBase.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpMetricsOptionsBase.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 
 namespace Prometheus.HttpMetrics
 {
@@ -21,5 +23,7 @@ namespace Prometheus.HttpMetrics
         /// Value is ignored if you specify a custom metric instance in the options.
         /// </summary>
         public CollectorRegistry? Registry { get; set; }
+
+        public Func<HttpContext, bool> IgnoreCondition { get; set; } = ctx => false;
     }
 }

--- a/Prometheus.AspNetCore/HttpMetrics/HttpMiddlewareExporterOptions.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpMiddlewareExporterOptions.cs
@@ -1,3 +1,6 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
 namespace Prometheus.HttpMetrics
 {
     public sealed class HttpMiddlewareExporterOptions
@@ -16,6 +19,13 @@ namespace Prometheus.HttpMetrics
             InProgress.AdditionalRouteParameters.Add(mapping);
             RequestCount.AdditionalRouteParameters.Add(mapping);
             RequestDuration.AdditionalRouteParameters.Add(mapping);
+        }
+
+        public void SetIgnoreCondition(Func<HttpContext, bool> ignoreCondition)
+        {
+            InProgress.IgnoreCondition = ignoreCondition;
+            RequestCount.IgnoreCondition = ignoreCondition;
+            RequestDuration.IgnoreCondition = ignoreCondition;
         }
     }
 }

--- a/Prometheus.AspNetCore/HttpMetrics/HttpRequestCountMiddleware.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpRequestCountMiddleware.cs
@@ -25,7 +25,7 @@ namespace Prometheus.HttpMetrics
                 // We need to record metrics after inner handler execution because routing data in
                 // ASP.NET Core 2 is only available *after* executing the next request delegate.
                 // So we would not have the right labels if we tried to create the child early on.
-                CreateChild(context).Inc();
+                CreateChild(context)?.Inc();
             }
         }
 

--- a/Prometheus.AspNetCore/HttpMetrics/HttpRequestDurationMiddleware.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpRequestDurationMiddleware.cs
@@ -30,7 +30,7 @@ namespace Prometheus.HttpMetrics
             {
                 stopWatch.Stop();
 
-                CreateChild(context).Observe(stopWatch.Elapsed.TotalSeconds);
+                CreateChild(context)?.Observe(stopWatch.Elapsed.TotalSeconds);
             }
         }
 

--- a/Prometheus.AspNetCore/HttpMetricsMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/HttpMetricsMiddlewareExtensions.cs
@@ -31,7 +31,7 @@ namespace Prometheus
         public static IApplicationBuilder UseHttpMetrics(this IApplicationBuilder app,
             HttpMiddlewareExporterOptions? options = null)
         {
-            options = options ?? new HttpMiddlewareExporterOptions();
+            options ??= new HttpMiddlewareExporterOptions();
 
             app.UseMiddleware<CaptureRouteDataMiddleware>();
 

--- a/Tests.NetCore/HttpExporter/RouteParameterMappingTests.cs
+++ b/Tests.NetCore/HttpExporter/RouteParameterMappingTests.cs
@@ -55,6 +55,21 @@ namespace Prometheus.Tests.HttpExporter
                 TestController
             }, child.Labels.Values);
         }
+        
+        [TestMethod]
+        public void DefaultMetric_IgnoreCondition()
+        {
+            SetupHttpContext(_context, TestStatusCode, TestMethod, TestAction, TestController);
+
+            var middleware = new HttpRequestCountMiddleware(_next, new HttpRequestCountOptions
+            {
+                IgnoreCondition = c => true,
+                Registry = _registry
+            });
+            var child = (ChildBase)middleware.CreateChild(_context);
+
+            Assert.IsNull(child);
+        }
 
         [TestMethod]
         public void CustomMetric_WithNoLabels_AppliesNoLabels()


### PR DESCRIPTION
In my case I have both gRpc and REST endpoints in my app. So, I don't want to write http metrics when processing gRPC request. With this changes I can filter gRPC requests, for example, by request contentType header. Something like this:
```
app.UseHttpMetrics(o =>
{
    o.SetIgnoreCondition(ctx => ctx.Request.ContentType == "application/grpc");
});
```
