### PR TITLE
Update the doc to mention aspnetcore 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ public void Configure(IApplicationBuilder app, ...)
 
     // ...
 
-    // ASP.NET Core 3 or newer
+    // ASP.NET Core 3.1 or newer
     app.UseEndpoints(endpoints =>
     {
         // ...


### PR DESCRIPTION
While it could, it doesn't work with 3.0 if the target-framework is set as `netcoreapp3.0`. 
See: https://github.com/prometheus-net/prometheus-net/commit/66ec9ebdc7f1a792fdcd6fa910aff6b6ee5c44b8