### PR TITLE
Add note on exposing metrics server outside localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ class Program
 }
 ```
 
+**NB!** Keep in mind that if you want to expose the metrics server outside of the local network you need to set the `hostname` to `*`.
+
 # Counters
 
 Counters only increase in value and reset to zero when the process restarts.


### PR DESCRIPTION
We noticed that we were unable to reach the metrics server from our Prometheus server in out Kubernetes environment. We had copied the example from the README where the metrics server which binds the `hostname` to `localhost`. Changing the it to `*` solved our problem.

This pull request adds a note to the README.md regarding this.

Related #246 #214