### PR TITLE
Await SendAsync to record correct duration

### DIFF
--- a/Prometheus.AspNetCore/HttpClientMetrics/HttpClientRequestDurationHandler.cs
+++ b/Prometheus.AspNetCore/HttpClientMetrics/HttpClientRequestDurationHandler.cs
@@ -11,11 +11,11 @@ namespace Prometheus.HttpClientMetrics
         {
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             using (CreateChild(request).NewTimer())
             {
-                return base.SendAsync(request, cancellationToken);
+                return await base.SendAsync(request, cancellationToken);
             }
         }
 

--- a/Tests.NetCore/HttpClientMetrics/HttpClientRequestDurationHandlerTests.cs
+++ b/Tests.NetCore/HttpClientMetrics/HttpClientRequestDurationHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Prometheus.HttpClientMetrics;
@@ -28,6 +29,52 @@ namespace Prometheus.Tests.HttpClientMetrics
 
             Assert.AreEqual(1, handler._metric.WithLabels("GET", "www.google.com").Count);
             Assert.IsTrue(handler._metric.WithLabels("GET", "www.google.com").Sum > 0);
+        }
+        
+        [TestMethod]
+        public void OnRequest_AwaitsRequestAndRecordsDuration()
+        {
+            var registry = Metrics.NewCustomRegistry();
+
+            var options = new HttpClientRequestDurationOptions
+            {
+                Registry = registry
+            };
+
+            var handler = new HttpClientRequestDurationHandler(options);
+
+            // Use a mock client handler so we can control when the task completes
+            var mockHttpClientHandler = new MockHttpClientHandler();
+            handler.InnerHandler = mockHttpClientHandler;
+
+            var client = new HttpClient(handler);
+            client.GetAsync("http://www.google.com");
+
+            // There should be no duration metric recorded unless the task is completed
+            Assert.AreEqual(0, handler._metric.WithLabels("GET", "www.google.com").Count);
+            
+            mockHttpClientHandler.Complete();
+            Assert.AreEqual(1, handler._metric.WithLabels("GET", "www.google.com").Count);
+        }
+
+        private class MockHttpClientHandler : HttpClientHandler
+        {
+            private readonly TaskCompletionSource<HttpResponseMessage> _taskCompletionSource;
+
+            public MockHttpClientHandler()
+            {
+                _taskCompletionSource = new TaskCompletionSource<HttpResponseMessage>();
+            }
+
+            public void Complete()
+            {
+                _taskCompletionSource.SetResult(new HttpResponseMessage());
+            }
+            
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return _taskCompletionSource.Task;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #265 

Await `base.SendAsync()` in `HttpClientRequestDurationHandler` to correctly record the request duration