### PR TITLE
Avoid allocating memory during calls to WithLabels

### DIFF
--- a/Benchmark.NetCore/Program.cs
+++ b/Benchmark.NetCore/Program.cs
@@ -6,12 +6,9 @@ namespace Benchmark.NetCore
     {
         private static void Main(string[] args)
         {
-            //BenchmarkRunner.Run<MetricCreationBenchmarks>();
-            //BenchmarkRunner.Run<SerializationBenchmarks>();
-            //BenchmarkRunner.Run<LabelBenchmarks>();
-            //BenchmarkRunner.Run<HttpExporterBenchmarks>();
-            //BenchmarkRunner.Run<SummaryBenchmarks>();
-            BenchmarkRunner.Run<MetricPusherBenchmarks>();
+            // Give user possibility to choose which benchmark to run.
+            // Can be overridden from the command line with the --filter option.
+            new BenchmarkSwitcher(typeof(Program).Assembly).Run(args);
         }
     }
 }

--- a/Prometheus.NetStandard/Collector.cs
+++ b/Prometheus.NetStandard/Collector.cs
@@ -144,6 +144,10 @@ namespace Prometheus
 
         private TChild GetOrAddLabelled(Labels key)
         {
+            // Don't allocate lambda for GetOrAdd in the common case that the labeled metrics exist.
+            if (_labelledMetrics.TryGetValue(key, out var metric))
+                return metric;
+
             return _labelledMetrics.GetOrAdd(key, k => NewChild(k, k.Concat(_staticLabels), publish: !_suppressInitialValue));
         }
 

--- a/Prometheus.NetStandard/Labels.cs
+++ b/Prometheus.NetStandard/Labels.cs
@@ -9,8 +9,12 @@ namespace Prometheus
     /// <remarks>
     /// Only the values are considered for equality purposes - the caller must ensure that
     /// LabelValues objects with different sets of names are never compared to each other.
+    /// 
+    /// Always use the explicit constructor when creating an instance. This is a struct in order
+    /// to reduce heap allocations when dealing with labelled metrics, which has the consequence of
+    /// adding a default parameterless constructor. It should not be used.
     /// </remarks>
-    internal sealed class Labels : IEquatable<Labels>
+    internal struct Labels : IEquatable<Labels>
     {
         public static readonly Labels Empty = new Labels(new string[0], new string[0]);
 
@@ -32,8 +36,11 @@ namespace Prometheus
             if (names.Length != values.Length)
                 throw new ArgumentException("The list of label values must have the same number of elements as the list of label names.");
 
-            if (values.Any(lv => lv == null))
-                throw new ArgumentNullException("A label value cannot be null.");
+            foreach (var lv in values)
+            {
+                if (lv == null)
+                    throw new ArgumentNullException("A label value cannot be null.");
+            }
 
             Values = values;
             Names = names;


### PR DESCRIPTION
These changes avoid heap allocation during calls to WithLabels.

* Make ``Labels`` a struct.
* Avoid allocating for lambda in use of ``Any`` in the Labels constructor.
* Avoid allocating for lambda in ``Collector::GetOrAddLabelled`` by only using ``ConcurrentDictionary::GetOrAdd`` if a call to ``TryGet`` returns false, which should only happen the first time a label is used.

Here are benchmark results from running the ``WithLabels_ManyMetrics_ManySeries`` benchmark.

```
|   Baseline (before)                 | 23,922.65 ns | 461.411 ns | 615.970 ns | 0.3357 |     - |     - |   13600 B |
|   Make Labels struct                | 23,991.09 ns | 118.811 ns |  92.760 ns | 0.2136 |     - |     - |    9600 B |
|   + Any() -> foreach in constructor | 19,441.14 ns | 361.153 ns | 301.579 ns | 0.1526 |     - |     - |    6400 B |
|   + GetOrAdd only if TryGet fails   | 16,954.60 ns | 294.131 ns | 275.130 ns |      - |     - |     - |         - |
```

Closes #274