### PR TITLE
Save allocation of Stopwatch in HttpRequestDurationMiddleware

### DIFF
--- a/Prometheus.AspNetCore/HttpMetrics/HttpRequestDurationMiddleware.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpRequestDurationMiddleware.cs
@@ -17,7 +17,7 @@ namespace Prometheus.HttpMetrics
 
         public async Task Invoke(HttpContext context)
         {
-            var stopWatch = Stopwatch.StartNew();
+            var stopWatch = ValueStopwatch.StartNew();
 
             // We need to write this out in long form instead of using a timer because routing data in
             // ASP.NET Core 2 is only available *after* executing the next request delegate.
@@ -28,9 +28,7 @@ namespace Prometheus.HttpMetrics
             }
             finally
             {
-                stopWatch.Stop();
-
-                CreateChild(context).Observe(stopWatch.Elapsed.TotalSeconds);
+                CreateChild(context).Observe(stopWatch.GetElapsedTime().TotalSeconds);
             }
         }
 

--- a/Prometheus.AspNetCore/ValueStopwatch.cs
+++ b/Prometheus.AspNetCore/ValueStopwatch.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Diagnostics;
+
+// Copied from: https://github.com/dotnet/extensions/blob/master/src/Shared/src/ValueStopwatch/ValueStopwatch.cs
+namespace Prometheus
+{
+    internal struct ValueStopwatch
+    {
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+        private long _startTimestamp;
+
+        public bool IsActive => _startTimestamp != 0;
+
+        private ValueStopwatch(long startTimestamp)
+        {
+            _startTimestamp = startTimestamp;
+        }
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+        public TimeSpan GetElapsedTime()
+        {
+            // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+            // So it being 0 is a clear indication of default(ValueStopwatch)
+            if (!IsActive)
+            {
+                throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+            }
+
+            var end = Stopwatch.GetTimestamp();
+            var timestampDelta = end - _startTimestamp;
+            var ticks = (long)(TimestampToTicks * timestampDelta);
+            return new TimeSpan(ticks);
+        }
+    }
+}


### PR DESCRIPTION
The `ValueStopwatch` struct mimics the behavior of `Stopwatch` class. The implementation is copied directly from [dotnet/extensions source code](https://github.com/dotnet/extensions/blob/master/src/Shared/src/ValueStopwatch/ValueStopwatch.cs).
