### PR TITLE
csproj updates for net5.0 support

### DIFF
--- a/Prometheus.AspNetCore.Grpc/Prometheus.AspNetCore.Grpc.csproj
+++ b/Prometheus.AspNetCore.Grpc/Prometheus.AspNetCore.Grpc.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>Prometheus</RootNamespace>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <SignAssembly>true</SignAssembly>
 
@@ -16,22 +17,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <NoWarn>1701;1702;1705;1591</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Prometheus.Grpc.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Prometheus.Grpc.xml</DocumentationFile>
+    <IsPackable>true</IsPackable>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\Resources\SolutionAssemblyInfo.cs" Link="SolutionAssemblyInfo.cs" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Grpc.AspNetCore.Server">
-      <Version>2.28.0</Version>
-    </PackageReference>
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.32.0"/> <!-- first version that has dedicated net5.0 support -->
     <ProjectReference Include="..\Prometheus.AspNetCore\Prometheus.AspNetCore.csproj" />
   </ItemGroup>
 

--- a/Prometheus.AspNetCore.HealthChecks/Prometheus.AspNetCore.HealthChecks.csproj
+++ b/Prometheus.AspNetCore.HealthChecks/Prometheus.AspNetCore.HealthChecks.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
 		<RootNamespace>Prometheus</RootNamespace>
 
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
 		<SignAssembly>true</SignAssembly>
 
@@ -14,33 +15,25 @@
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors />
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DocumentationFile>bin\Release\netstandard2.0\Prometheus.AspNetCore.HealthChecks.xml</DocumentationFile>
 		<CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
 		<NoWarn>1701;1702;1705;1591</NoWarn>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DocumentationFile>bin\Debug\netstandard2.0\Prometheus.AspNetCore.HealthChecks.xml</DocumentationFile>
-		<CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-		<NoWarn>1701;1702;1705;1591</NoWarn>
+		<IsPackable>true</IsPackable>
+		<OutputType>Library</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<Compile Include="..\Resources\SolutionAssemblyInfo.cs" Link="SolutionAssemblyInfo.cs" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
-
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.5" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.3" />
 	</ItemGroup>
 

--- a/Prometheus.AspNetCore/HttpClientMetrics/HttpClientDelegatingHandlerBase.cs
+++ b/Prometheus.AspNetCore/HttpClientMetrics/HttpClientDelegatingHandlerBase.cs
@@ -68,7 +68,7 @@ namespace Prometheus.HttpClientMetrics
                         labelValues[i] = request.Method.Method;
                         break;
                     case HttpClientRequestLabelNames.Host:
-                        labelValues[i] = request.RequestUri.Host;
+                        labelValues[i] = request.RequestUri?.Host ?? string.Empty;
                         break;
                     default:
                         // We validate the label set on initialization, so this is impossible.

--- a/Prometheus.AspNetCore/KestrelMetricServer.cs
+++ b/Prometheus.AspNetCore/KestrelMetricServer.cs
@@ -56,7 +56,7 @@ namespace Prometheus
                     // If there is any URL prefix, we just redirect people going to root URL to our prefix.
                     if (!string.IsNullOrWhiteSpace(_url.Trim('/')))
                     {
-                        app.MapWhen(context => context.Request.Path.Value.Trim('/') == "",
+                        app.MapWhen(context => context.Request.Path.Value?.Trim('/') == "",
                             configuration =>
                             {
                                 configuration.Use((context, next) =>

--- a/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
@@ -8,7 +8,7 @@ namespace Prometheus
     public static class MetricServerMiddlewareExtensions
     {
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1 || NET5_0
 
         private const string DefaultDisplayName = "Prometheus metrics";
 

--- a/Prometheus.AspNetCore/Prometheus.AspNetCore.csproj
+++ b/Prometheus.AspNetCore/Prometheus.AspNetCore.csproj
@@ -1,11 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>Prometheus</RootNamespace>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <SignAssembly>true</SignAssembly>
 
     <AssemblyOriginatorKeyFile>..\Resources\prometheus-net.snk</AssemblyOriginatorKeyFile>
@@ -14,33 +16,24 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors />
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Prometheus.AspNetCore.xml</DocumentationFile>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Prometheus.AspNetCore.xml</DocumentationFile>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <NoWarn>1701;1702;1705;1591</NoWarn>
+    <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\Resources\SolutionAssemblyInfo.cs" Link="SolutionAssemblyInfo.cs" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
   
+  <!-- NS2.0 doesn't include aspnetcore libs so we need to include that for consumers -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
   </ItemGroup>
   

--- a/Prometheus.NetStandard/Prometheus.NetStandard.csproj
+++ b/Prometheus.NetStandard/Prometheus.NetStandard.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -32,6 +29,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <!-- Enables building, but not necessarily running on non-windows systems -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/Tester.AspNetCore.HealthChecks/Tester.AspNetCore.HealthChecks.csproj
+++ b/Tester.AspNetCore.HealthChecks/Tester.AspNetCore.HealthChecks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tester.NetCore/tester.netcore.csproj
+++ b/Tester.NetCore/tester.netcore.csproj
@@ -2,26 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>tester</RootNamespace>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>prometheus-net.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <LangVersion>latest</LangVersion>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
-    <LangVersion>latest</LangVersion>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-  </PropertyGroup>
-
+  
   <ItemGroup>
     <Compile Remove="Controllers\**" />
     <EmbeddedResource Remove="Controllers\**" />
@@ -38,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.29.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.32.0"/> <!-- first version that has dedicated net5.0 support -->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #267 by adding an additional multitarget for net5.0 whereever we had a prior one for netcoreapp3.1.

This results in packages with TFM groups for

* netstandard2.0
* netcoreapp3.1
* net5.0

The addition of the explicit net5.0 group prevents .net5.0-targeting consumers from falling-back to the netstandard2.0 dependencies, because net5.0 does not fallback to netcoreapp3.1 in nuget-TFM-parlance.

In general, I had to do the same kinds of operations through this work:

* add the new net5.0 TFM
* check additional dependencies in the project to key the use of specific versions off of which TFM was being targeted
* scope the variations to be a tightly-scoped as possible, to make the full set of changes easy to reason about.

After this work, the nuget packages expose the following dependency graph:

![image](https://user-images.githubusercontent.com/573979/114578839-e7765a80-9c42-11eb-91ab-e6874232c3fa.png)

Which looks perfect to me. No net5.0 TFMs have 3.x dependencies or AspNetCore 2.x dependencies, and no netcoreapp3.1/netstandard2.0 TFMs have any net50 dependencies.
