### PR TITLE
Add initial OpenMetrics support

### DIFF
--- a/Prometheus.AspNetCore/MetricServerMiddleware.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddleware.cs
@@ -27,6 +27,8 @@ namespace Prometheus
         public async Task Invoke(HttpContext context)
         {
             var response = context.Response;
+            var contentType = context.Request.Headers["Accept"].ToString().Contains("application/openmetrics-text") ?
+                PrometheusConstants.ExporterContentTypeOpenMetrics : PrometheusConstants.ExporterContentType;
 
             try
             {
@@ -34,10 +36,10 @@ namespace Prometheus
                 // it means we can no longer send headers (the status code).
                 var serializer = new TextSerializer(delegate
                 {
-                    response.ContentType = PrometheusConstants.ExporterContentType;
+                    response.ContentType = contentType;
                     response.StatusCode = StatusCodes.Status200OK;
                     return response.Body;
-                });
+                }, contentType);
 
                 await _registry.CollectAndSerializeAsync(serializer, context.RequestAborted);
             }

--- a/Prometheus.NetStandard/IMetricsSerializer.cs
+++ b/Prometheus.NetStandard/IMetricsSerializer.cs
@@ -24,5 +24,11 @@ namespace Prometheus
         /// Flushes any pending buffers. Always call this after all your write calls.
         /// </summary>
         Task FlushAsync(CancellationToken cancel);
+
+        /// <summary>
+        /// The content type of the serializer. Serialization for some metric families depends on the
+        /// nature of the output format.
+        /// </summary>
+        string ContentType();
     }
 }

--- a/Prometheus.NetStandard/MetricServer.cs
+++ b/Prometheus.NetStandard/MetricServer.cs
@@ -67,16 +67,19 @@ namespace Prometheus
                                     return;
                                 }
 
+                                var contentType = request.Headers["Accept"].ToString().Contains("application/openmetrics-text") ?
+                                    PrometheusConstants.ExporterContentTypeOpenMetrics : PrometheusConstants.ExporterContentType;
+
                                 try
                                 {
                                     // We first touch the response.OutputStream only in the callback because touching
                                     // it means we can no longer send headers (the status code).
                                     var serializer = new TextSerializer(delegate
                                     {
-                                        response.ContentType = PrometheusConstants.ExporterContentType;
+                                        response.ContentType = contentType;
                                         response.StatusCode = 200;
                                         return response.OutputStream;
-                                    });
+                                    }, contentType);
 
                                     await _registry.CollectAndSerializeAsync(serializer, cancel);
                                     response.OutputStream.Dispose();

--- a/Prometheus.NetStandard/MetricType.cs
+++ b/Prometheus.NetStandard/MetricType.cs
@@ -2,6 +2,7 @@
 {
     internal enum MetricType
     {
+        Unknown,
         Counter,
         Gauge,
         Summary,

--- a/Prometheus.NetStandard/PrometheusConstants.cs
+++ b/Prometheus.NetStandard/PrometheusConstants.cs
@@ -5,6 +5,7 @@ namespace Prometheus
     public static class PrometheusConstants
     {
         public const string ExporterContentType = "text/plain; version=0.0.4; charset=utf-8";
+        public const string ExporterContentTypeOpenMetrics = "application/openmetrics-text; version=0.0.1; charset=utf-8";
 
         // ASP.NET does not want to accept the parameters in PushStreamContent for whatever reason...
         public const string ExporterContentTypeMinimal = "text/plain";

--- a/Prometheus.NetStandard/TextSerializer.cs
+++ b/Prometheus.NetStandard/TextSerializer.cs
@@ -14,15 +14,17 @@ namespace Prometheus
         private static readonly byte[] NewLine = new[] { (byte)'\n' };
         private static readonly byte[] Space = new[] { (byte)' ' };
 
-        public TextSerializer(Stream stream)
+        public TextSerializer(Stream stream, string contentType = PrometheusConstants.ExporterContentType)
         {
             _stream = new Lazy<Stream>(() => stream);
+            _contentType = contentType;
         }
 
         // Enables delay-loading of the stream, because touching stream in HTTP handler triggers some behavior.
-        public TextSerializer(Func<Stream> streamFactory)
+        public TextSerializer(Func<Stream> streamFactory, string contentType = PrometheusConstants.ExporterContentType)
         {
             _stream = new Lazy<Stream>(streamFactory);
+            _contentType = contentType;
         }
 
         public async Task FlushAsync(CancellationToken cancel)
@@ -35,6 +37,7 @@ namespace Prometheus
         }
 
         private readonly Lazy<Stream> _stream;
+        private readonly string _contentType;
 
         // # HELP name help
         // # TYPE name type
@@ -67,5 +70,7 @@ namespace Prometheus
             await _stream.Value.WriteAsync(_stringBytesBuffer, 0, numBytes, cancel);
             await _stream.Value.WriteAsync(NewLine, 0, NewLine.Length, cancel);
         }
+
+        public string ContentType() => _contentType;
     }
 }

--- a/Prometheus.NetStandard/TextSerializer.cs
+++ b/Prometheus.NetStandard/TextSerializer.cs
@@ -13,6 +13,7 @@ namespace Prometheus
     {
         private static readonly byte[] NewLine = new[] { (byte)'\n' };
         private static readonly byte[] Space = new[] { (byte)' ' };
+        private static readonly byte[] Eof = new[] { (byte)'#', (byte)' ', (byte)'E', (byte)'O', (byte)'F' };
 
         public TextSerializer(Stream stream, string contentType = PrometheusConstants.ExporterContentType)
         {
@@ -29,6 +30,12 @@ namespace Prometheus
 
         public async Task FlushAsync(CancellationToken cancel)
         {
+            if (_contentType == PrometheusConstants.ExporterContentTypeOpenMetrics)
+            {
+                // The OpenMetrics format requires that the stream end with "# EOF".
+                await _stream.Value.WriteAsync(Eof, 0, Eof.Length, cancel);
+            }
+
             // If we never opened the stream, we don't touch it on flush.
             if (!_stream.IsValueCreated)
                 return;

--- a/Tests.NetCore/OpenMetricsTests.cs
+++ b/Tests.NetCore/OpenMetricsTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Prometheus.Tests
@@ -16,6 +17,34 @@ namespace Prometheus.Tests
 
                 serializer = new TextSerializer(stream, PrometheusConstants.ExporterContentTypeOpenMetrics);
                 Assert.AreEqual(serializer.ContentType(), PrometheusConstants.ExporterContentTypeOpenMetrics);
+            }
+        }
+
+        [TestMethod]
+        public async Task Serializer_WritesEofBytes()
+        {
+            MemoryStream stream;
+            TextSerializer serializer;
+            string text;
+
+            // The legacy format can be totally empty.
+            using(stream = new MemoryStream())
+            {
+                serializer = new TextSerializer(stream);
+                await serializer.FlushAsync(default);
+                stream.Position = 0;
+                text = new StreamReader(stream).ReadToEnd();
+                Assert.AreEqual(text, "");
+            }
+
+            // The OpenMetrics format must end with "# EOF".
+            using(stream = new MemoryStream())
+            {
+                serializer = new TextSerializer(stream, PrometheusConstants.ExporterContentTypeOpenMetrics);
+                await serializer.FlushAsync(default);
+                stream.Position = 0;
+                text = new StreamReader(stream).ReadToEnd();
+                StringAssert.EndsWith(text, "# EOF");
             }
         }
     }

--- a/Tests.NetCore/OpenMetricsTests.cs
+++ b/Tests.NetCore/OpenMetricsTests.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Prometheus.Tests
+{
+    [TestClass]
+    public class OpenMetricsTests
+    {
+        [TestMethod]
+        public void Serializer_ExposesContentType()
+        {
+            using(var stream = new MemoryStream())
+            {
+                var serializer = new TextSerializer(stream);
+                Assert.AreEqual(serializer.ContentType(), PrometheusConstants.ExporterContentType);
+
+                serializer = new TextSerializer(stream, PrometheusConstants.ExporterContentTypeOpenMetrics);
+                Assert.AreEqual(serializer.ContentType(), PrometheusConstants.ExporterContentTypeOpenMetrics);
+            }
+        }
+    }
+}


### PR DESCRIPTION
As proposed in #284: the new [OpenMetrics](https://openmetrics.io/) standard is the next-gen format for consuming and emitting Prometheus metrics, and has been supported by Prometheus itself for a few years now.

This PR does the following to achieve basic compatibility but doesn't add any OpenMetrics-specific features:

* Make the serializer aware of the content type it is writing so it can handle different scenarios internally.
* Ensure the stream ends with `# EOF` when writing the OpenMetrics format (as required by the standard).
* Work around Counter incompatibilities in the OpenMetrics format.
* Serve the OpenMetrics format from the MetricServer and Asp.Net Core middleware via Content-Type negotiation.

There are tests for all new features included, and I have also tested that metrics emitted with these changes can be parsed by the [de-facto standard OpenMetrics parser](https://github.com/OpenObservability/OpenMetrics/blob/main/tests/implementations/prometheus_client_python_parser/parser.py) (part of the Prometheus Python client).

I'm happy to take criticism of the implementation, as well. As an aside: I have actually implemented most of the OpenMetrics features on top of these changes (including `_created`, units, and exemplars with automatic trace ID injection), so if there is interest I can attempt to upstream those as well.

cc @joe-elliott