### PR TITLE
Handle HttpClient timeout to avoid terminating push thread

### DIFF
--- a/Prometheus.NetStandard/MetricPusher.cs
+++ b/Prometheus.NetStandard/MetricPusher.cs
@@ -110,7 +110,7 @@ namespace Prometheus
                         // We do not consider failed scrapes a reportable error since the user code that raises the failure should be the one logging it.
                         Trace.WriteLine($"Skipping metrics push due to failed scrape: {ex.Message}");
                     }
-                    catch (Exception ex) when (!(ex is OperationCanceledException))
+                    catch (Exception ex)
                     {
                         HandleFailedPush(ex);
                     }

--- a/Tests.NetFramework/MetricPusherTests.cs
+++ b/Tests.NetFramework/MetricPusherTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Prometheus.Tests
 {
@@ -36,6 +38,69 @@ namespace Prometheus.Tests
             Assert.IsNotNull(lastError);
 
             pusher.Stop();
+        }
+
+        [TestMethod]
+        public void HttpClient_OnInvalidRequestUri_CallsErrorCallback()
+        {
+            RunHttpClientExceptionScenario(new InvalidOperationException("Simulating an invalid request uri according to HttpClient documentation."));
+        }
+
+        [TestMethod]
+        public void HttpClient_OnUnderlyingConnectionIssue_CallsErrorCallback()
+        {
+            RunHttpClientExceptionScenario(new HttpRequestException("Simulating an underlying connection issue according to HttpClient documentation."));
+        }
+
+        [TestMethod]
+        public void HttpClient_OnTimeout_CallsErrorCallback()
+        {
+            RunHttpClientExceptionScenario(new TaskCanceledException("Simulating a timeout according to HttpClient documentation."));
+        }
+
+        private void RunHttpClientExceptionScenario(Exception throwOnHttpPost)
+        {
+            Exception lastError = null;
+            var onErrorCalled = new ManualResetEventSlim();
+
+            void OnError(Exception ex)
+            {
+                lastError = ex;
+                onErrorCalled.Set();
+            }
+
+            var pusher = new MetricPusher(new MetricPusherOptions
+            {
+                Job = "Test",
+                // Small interval to ensure that we exit fast.
+                IntervalMilliseconds = 100,
+                Endpoint = "https://any_valid.url/the_push_fails_with_fake_httpclient_throwing_exceptions",
+                OnError = OnError,
+                HttpClientProvider = () => new ThrowingHttpClient(throwOnHttpPost)
+            });
+
+            pusher.Start();
+
+            var onErrorWasCalled = onErrorCalled.Wait(TimeSpan.FromSeconds(5));
+            Assert.IsTrue(onErrorWasCalled, "OnError was not called even though the push failed.");
+            Assert.IsNotNull(lastError);
+
+            pusher.Stop();
+        }
+
+        private class ThrowingHttpClient : HttpClient
+        {
+            private readonly Exception _throwOnSend;
+            public ThrowingHttpClient(Exception ex)
+            {
+                _throwOnSend = ex;
+            }
+            
+            // PostAsync eventually calls SendAsync
+            public override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw _throwOnSend;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #293 

We've experienced production problems where the push thread terminated even though the host worker ran fine. 

The referenced issue #293 describes that the HttpClient, in case of a timeout will throw TaskCanceledException, a subtype of OperationCanceledException. We've recreated the error manually by setting HttpClient timeout to 1ms. This killed the push thread.

We can't see why exceptions inheriting OperationCanceledExceptions should be allowed to terminate the thread. The existing cancellation token handling seems sufficient.

This PR adds a fix in MetricPusher.cs + test scenarios that ensure that the exception types documented on PostAsync all results in a OnError callback. The timeout scenario yielded a breaking test before updating line 113 in MetricPusher.cs:
```c#
catch (Exception ex) // delete: when (!(ex is OperationCanceledException))
```

HttpClient PostAsync documentation: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.postasync?view=net-5.0