### PR TITLE
Add HttpStatusCode to HttpClient metrics

### DIFF
--- a/Prometheus.AspNetCore/HttpClientMetrics/HttpClientRequestLabelNames.cs
+++ b/Prometheus.AspNetCore/HttpClientMetrics/HttpClientRequestLabelNames.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Prometheus.HttpClientMetrics
 {
     /// <summary>
@@ -7,8 +9,16 @@ namespace Prometheus.HttpClientMetrics
     {
         public const string Method = "method";
         public const string Host = "host";
+        public const string Code = "code";
 
         public static readonly string[] All =
+        {
+            Code,
+            Method,
+            Host
+        };
+
+        internal static readonly string[] AvailableBeforeRequest =
         {
             Method,
             Host

--- a/Tests.NetCore/HttpClientMetrics/HttpClientRequestCountHandlerTests.cs
+++ b/Tests.NetCore/HttpClientMetrics/HttpClientRequestCountHandlerTests.cs
@@ -26,7 +26,7 @@ namespace Prometheus.Tests.HttpClientMetrics
             var client = new HttpClient(handler);
             await client.GetAsync("http://www.google.com");
 
-            Assert.AreEqual(1, handler._metric.WithLabels("GET", "www.google.com").Value);
+            Assert.AreEqual(1, handler._metric.WithLabels("200", "GET", "www.google.com").Value);
         }
     }
 }

--- a/Tests.NetCore/HttpClientMetrics/HttpClientRequestDurationHandlerTests.cs
+++ b/Tests.NetCore/HttpClientMetrics/HttpClientRequestDurationHandlerTests.cs
@@ -27,8 +27,8 @@ namespace Prometheus.Tests.HttpClientMetrics
             var client = new HttpClient(handler);
             await client.GetAsync("http://www.google.com");
 
-            Assert.AreEqual(1, handler._metric.WithLabels("GET", "www.google.com").Count);
-            Assert.IsTrue(handler._metric.WithLabels("GET", "www.google.com").Sum > 0);
+            Assert.AreEqual(1, handler._metric.WithLabels("200", "GET", "www.google.com").Count);
+            Assert.IsTrue(handler._metric.WithLabels("200", "GET", "www.google.com").Sum > 0);
         }
         
         [TestMethod]
@@ -51,10 +51,10 @@ namespace Prometheus.Tests.HttpClientMetrics
             client.GetAsync("http://www.google.com");
 
             // There should be no duration metric recorded unless the task is completed
-            Assert.AreEqual(0, handler._metric.WithLabels("GET", "www.google.com").Count);
+            Assert.AreEqual(0, handler._metric.WithLabels("200", "GET", "www.google.com").Count);
             
             mockHttpClientHandler.Complete();
-            Assert.AreEqual(1, handler._metric.WithLabels("GET", "www.google.com").Count);
+            Assert.AreEqual(1, handler._metric.WithLabels("200", "GET", "www.google.com").Count);
         }
 
         private class MockHttpClientHandler : HttpClientHandler


### PR DESCRIPTION
Closes #294

This adds the Code label to all `HttpClient` metrics, this might warrant some extra tests so some non existent domains or paths to test say 404 or other exception creating circumstances.