### PR TITLE
Add metric for the aggregate health status

### DIFF
--- a/Prometheus.AspNetCore.HealthChecks/PrometheusHealthCheckPublisher.cs
+++ b/Prometheus.AspNetCore.HealthChecks/PrometheusHealthCheckPublisher.cs
@@ -19,6 +19,8 @@ namespace Prometheus
 
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
         {
+            _checkStatus.Set(HealthStatusToMetricValue(report.Status));
+        
             foreach (var reportEntry in report.Entries)
                 _checkStatus.WithLabels(reportEntry.Key).Set(HealthStatusToMetricValue(reportEntry.Value.Status));
 


### PR DESCRIPTION
Right now only the health status of all dependencies is forwarded to prometheus and not the aggegated health status. If you want to figure out the overall health of a service you have to implement logic right now in prometheus queries. This PR should fix that.