### PR TITLE
Allow custom routes via AspNetMetricServer

### DIFF
--- a/Prometheus.NetFramework.AspNet/AspNetMetricServer.cs
+++ b/Prometheus.NetFramework.AspNet/AspNetMetricServer.cs
@@ -32,7 +32,7 @@ namespace Prometheus
         {
             if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration));
-            
+
             configuration.Routes.MapHttpRoute(
                 name: $"{RouteNamePrefix}{routeName}",
                 routeTemplate: routePath,

--- a/Prometheus.NetFramework.AspNet/AspNetMetricServer.cs
+++ b/Prometheus.NetFramework.AspNet/AspNetMetricServer.cs
@@ -9,6 +9,8 @@ namespace Prometheus
 {
     public static class AspNetMetricServer
     {
+        private const string RouteNamePrefix = "Prometheus_";
+        
         public sealed class Settings
         {
             public CollectorRegistry Registry { get; set; }
@@ -17,14 +19,23 @@ namespace Prometheus
         /// <summary>
         /// Registers an anonymous instance of the controller to be published on the /metrics URL.
         /// </summary>
-        public static void RegisterRoutes(HttpConfiguration configuration, Settings settings = null)
+        public static void RegisterRoutes(HttpConfiguration configuration, Settings settings = null) =>
+            MapRoute(configuration, "Default", "metrics", settings);
+        
+        /// <summary>
+        /// Registers an anonymous instance of the controller to be published on a given URL.
+        /// </summary>
+        public static void RegisterCustomRoutes(HttpConfiguration configuration, string route, Settings settings = null) =>
+            MapRoute(configuration, route, route, settings);
+
+        private static void MapRoute(HttpConfiguration configuration, string routeName, string routePath, Settings settings)
         {
             if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration));
-
+            
             configuration.Routes.MapHttpRoute(
-                name: "Prometheus_Default",
-                routeTemplate: "metrics",
+                name: $"{RouteNamePrefix}{routeName}",
+                routeTemplate: routePath,
                 defaults: null,
                 constraints: null,
                 handler: new Handler(settings?.Registry ?? Metrics.DefaultRegistry));

--- a/Tester.NetFramework.AspNet/Global.asax.cs
+++ b/Tester.NetFramework.AspNet/Global.asax.cs
@@ -9,6 +9,7 @@ namespace Tester.NetFramework.AspNet
         protected void Application_Start(object sender, EventArgs e)
         {
             AspNetMetricServer.RegisterRoutes(GlobalConfiguration.Configuration);
+            AspNetMetricServer.RegisterCustomRoutes(GlobalConfiguration.Configuration, "metrics/alternate");
         }
     }
 }


### PR DESCRIPTION
This already looks to be possible with Prometheus.AspNetCore, but I couldn't see a simple way to do it with Prometheus.NetFramework.AspNet.