### PR TITLE
[wip] expose http metrics with customized routing data

### DIFF
--- a/Prometheus.AspNetCore/HttpMetrics/HttpMiddlewareExporterOptions.cs
+++ b/Prometheus.AspNetCore/HttpMetrics/HttpMiddlewareExporterOptions.cs
@@ -1,3 +1,7 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using System;
+
 namespace Prometheus.HttpMetrics
 {
     public sealed class HttpMiddlewareExporterOptions
@@ -6,6 +10,7 @@ namespace Prometheus.HttpMetrics
         public HttpRequestCountOptions RequestCount { get; set; } = new HttpRequestCountOptions();
         public HttpRequestDurationOptions RequestDuration { get; set; } = new HttpRequestDurationOptions();
 
+        public Func<RouteValueDictionary, HttpContext, int>? CustomizeRouteValueDictionaryFunc = null;
         /// <summary>
         /// Whether to capture metrics for queries to the /metrics endpoint (where metrics are exported by default). Defaults to false.
         /// This matches against URLs starting with the /metrics string specifically - if you use a custom metrics endpoint, this will not match.

--- a/Prometheus.AspNetCore/HttpMetricsMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/HttpMetricsMiddlewareExtensions.cs
@@ -35,7 +35,7 @@ namespace Prometheus
 
             void ApplyConfiguration(IApplicationBuilder builder)
             {
-                builder.UseMiddleware<CaptureRouteDataMiddleware>();
+                builder.UseMiddleware<CaptureRouteDataMiddleware>(options);
 
                 if (options.InProgress.Enabled)
                     builder.UseMiddleware<HttpInProgressMiddleware>(options.InProgress);


### PR DESCRIPTION
With current code base, we can extend the label of http metrics by AddRouteParameter().  
But sometimes,  the request.path can't be mapped to RouteData directly.   So, we hope to have an approach to add some raw path info as label. 

With the changes in this PR,   the end-user can simply tweak the CapturedRouteDataFeature.Values table to add some customized path as label. 

i.e.  with below code,  I can add a label named "RegexPath" into the exported http metrics, and tweak all the random numbers in my request url,i.e. '/api/Values/50' to (id) by Regex replacement: 
```
            app.UseHttpMetrics(options => {

                options.AddRouteParameter("RegexPath");

                options.CustomizeRouteValueDictionaryFunc = (RouteValueDictionary routeValueDictionary, HttpContext context) => {
                    routeValueDictionary.Add("RegexPath", GetRegexPath(context.Request));
                    return 1;
               };

            });
```

The result is:
```
http_request_duration_seconds_sum{code="200",method="GET",controller="",action="",RegexPath="/"} 0.1384843
http_request_duration_seconds_count{code="200",method="GET",controller="",action="",RegexPath="/"} 1
http_request_duration_seconds_bucket{code="200",method="GET",controller="",action="",RegexPath="/",le="0.001"} 0
http_request_duration_seconds_bucket{code="200",method="GET",controller="",action="",RegexPath="/",le="0.002"} 0
....
http_request_duration_seconds_count{code="200",method="GET",controller="",action="",RegexPath="/api/Values"} 1
http_request_duration_seconds_bucket{code="200",method="GET",controller="",action="",RegexPath="/api/Values",le="0.001"} 0
http_request_duration_seconds_bucket{code="200",method="GET",controller="",action="",RegexPath="/api/Values",le="0.002"} 0
http_request_duration_seconds_bucket{code="200",method="GET",controller="",action="",RegexPath="/api/Values",le="0.004"} 0
...
http_request_duration_seconds_sum{code="404",method="GET",controller="",action="",RegexPath="/api/Values/(id)"} 0.0006978
http_request_duration_seconds_count{code="404",method="GET",controller="",action="",RegexPath="/api/Values/(id)"} 1
http_request_duration_seconds_bucket{code="404",method="GET",controller="",action="",RegexPath="/api/Values/(id)",le="0.001"} 1
http_request_duration_seconds_bucket{code="404",method="GET",controller="",action="",RegexPath="/api/Values/(id)",le="0.002"} 1
http_request_duration_seconds_bucket{code="404",method="GET",controller="",action="",RegexPath="/api/Values/(id)",le="0.004"} 1
http_request_duration_seconds_bucket{code="404",method="GET",controller="",action="",RegexPath="/api/Values/(id)",le="0.008"} 1
```

This is just a draft PR.  If  the idea is acceptable,  I will add relative unit test for it. 
