### PR TITLE
Use built in way to calculate unix time

### DIFF
--- a/Prometheus.NetStandard/DotNetStats.cs
+++ b/Prometheus.NetStandard/DotNetStats.cs
@@ -59,8 +59,7 @@ namespace Prometheus
             // .net specific metrics
             _totalMemory = metrics.CreateGauge("dotnet_total_memory_bytes", "Total known allocated memory");
 
-            var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            _startTime.Set((_process.StartTime.ToUniversalTime() - epoch).TotalSeconds);
+            _startTime.Set(new DateTimeOffset(_process.StartTime).ToUnixTimeSeconds());
         }
 
         // The Process class is not thread-safe so let's synchronize the updates to avoid data tearing.


### PR DESCRIPTION
Slightest imporvement possible but it saves a line and uses a standard way to convert it. Available in all the standards since Framework 4.6