### PR TITLE
Openmetrics refactor and tests

### DIFF
--- a/Prometheus/CanonicalLabel.cs
+++ b/Prometheus/CanonicalLabel.cs
@@ -1,0 +1,21 @@
+﻿namespace Prometheus;
+
+internal readonly struct CanonicalLabel
+{
+    public static readonly CanonicalLabel Empty = new(
+        Array.Empty<byte>(), Array.Empty<byte>(), Array.Empty<byte>());
+
+    public CanonicalLabel(byte[] name, byte[] prometheus, byte[] openMetrics)
+    {
+        Prometheus = prometheus;
+        OpenMetrics = openMetrics;
+        Name = name;
+    }
+
+    public byte[] Name { get;  }
+    
+    public byte[] Prometheus { get;  }
+    public byte[] OpenMetrics { get;  }
+
+    public bool IsNotEmpty => Name.Length > 0;
+}

--- a/Prometheus/ChildBase.cs
+++ b/Prometheus/ChildBase.cs
@@ -7,7 +7,7 @@ namespace Prometheus
     {
         internal ChildBase(Collector parent, LabelSequence instanceLabels, LabelSequence flattenedLabels, bool publish)
         {
-            _parent = parent;
+            Parent = parent;
             InstanceLabels = instanceLabels;
             FlattenedLabels = flattenedLabels;
             FlattenedLabelsBytes = PrometheusConstants.ExportEncoding.GetBytes(flattenedLabels.Serialize());
@@ -44,7 +44,7 @@ namespace Prometheus
         /// </summary>
         public void Remove()
         {
-            _parent.RemoveLabelled(InstanceLabels);
+            Parent.RemoveLabelled(InstanceLabels);
         }
 
         public void Dispose() => Remove();
@@ -60,9 +60,10 @@ namespace Prometheus
         /// Internal for testing purposes only.
         /// </summary>
         internal LabelSequence FlattenedLabels { get; }
+
         internal byte[] FlattenedLabelsBytes { get; }
-        
-        internal readonly Collector _parent;         // TODO: rename to Parent (right?)
+
+        internal readonly Collector Parent;
 
         private bool _publish;
 

--- a/Prometheus/Collector.cs
+++ b/Prometheus/Collector.cs
@@ -227,7 +227,9 @@ namespace Prometheus
 
             _familyHeaderLines = new byte[][]
             {
-                PrometheusConstants.ExportEncoding.GetBytes($"# HELP {name} {help}"),
+                string.IsNullOrWhiteSpace(help)
+                    ? PrometheusConstants.ExportEncoding.GetBytes($"# HELP {name}")
+                    : PrometheusConstants.ExportEncoding.GetBytes($"# HELP {name} {help}"),
                 PrometheusConstants.ExportEncoding.GetBytes($"# TYPE {name} {Type.ToString().ToLowerInvariant()}")
             };
         }

--- a/Prometheus/Counter.cs
+++ b/Prometheus/Counter.cs
@@ -13,8 +13,12 @@ namespace Prometheus
 
             private protected override async Task CollectAndSerializeImplAsync(IMetricsSerializer serializer, CancellationToken cancel)
             {
-                await serializer.WriteIdentifierPartAsync(this.Parent.NameBytes, this.FlattenedLabelsBytes, cancel);
-                await serializer.WriteValuePartAsync(Value, cancel);
+                await serializer.WriteMetricPointAsync(
+                    Parent.NameBytes,
+                    FlattenedLabelsBytes,
+                    CanonicalLabel.Empty,
+                    cancel, 
+                    Value);
             }
 
             public void Inc(double increment = 1.0)

--- a/Prometheus/Counter.cs
+++ b/Prometheus/Counter.cs
@@ -13,7 +13,7 @@ namespace Prometheus
 
             private protected override async Task CollectAndSerializeImplAsync(IMetricsSerializer serializer, CancellationToken cancel)
             {
-                await serializer.WriteIdentifierPartAsync(this._parent.NameBytes, this.FlattenedLabelsBytes, cancel);
+                await serializer.WriteIdentifierPartAsync(this.Parent.NameBytes, this.FlattenedLabelsBytes, cancel);
                 await serializer.WriteValuePartAsync(Value, cancel);
             }
 

--- a/Prometheus/Gauge.cs
+++ b/Prometheus/Gauge.cs
@@ -13,7 +13,7 @@
 
             private protected override async Task CollectAndSerializeImplAsync(IMetricsSerializer serializer, CancellationToken cancel)
             {
-                await serializer.WriteIdentifierPartAsync(_parent.NameBytes,FlattenedLabelsBytes, cancel);
+                await serializer.WriteIdentifierPartAsync(Parent.NameBytes,FlattenedLabelsBytes, cancel);
                 await serializer.WriteValuePartAsync(Value, cancel);
             }
 

--- a/Prometheus/Gauge.cs
+++ b/Prometheus/Gauge.cs
@@ -13,8 +13,8 @@
 
             private protected override async Task CollectAndSerializeImplAsync(IMetricsSerializer serializer, CancellationToken cancel)
             {
-                await serializer.WriteIdentifierPartAsync(Parent.NameBytes,FlattenedLabelsBytes, cancel);
-                await serializer.WriteValuePartAsync(Value, cancel);
+                await serializer.WriteMetricPointAsync(
+                    Parent.NameBytes, FlattenedLabelsBytes, CanonicalLabel.Empty, cancel, Value);
             }
 
             public void Inc(double increment = 1)

--- a/Prometheus/IMetricsSerializer.cs
+++ b/Prometheus/IMetricsSerializer.cs
@@ -13,16 +13,11 @@
         Task WriteFamilyDeclarationAsync(byte[][] headerLines, CancellationToken cancel);
 
         /// <summary>
-        /// Writes the second part of the metric, the value (and the exemplar). Terminates with a newline 
+        /// Writes out a single metric point
         /// </summary>
-        Task WriteValuePartAsync(double value, CancellationToken cancel);
-
-        /// <summary>
-        /// Writes the identifier for a series. Terminates with a SPACE. 
-        /// </summary>
-        Task WriteIdentifierPartAsync(byte[] name, byte[] flatennedLabels, CancellationToken cancel, 
-            byte[]? postfix = null, byte[]? extraLabelName = null, byte[]? extraLabelValue = null,
-            byte[]? extraLabelValueOpenMetrics = null);
+        /// <returns></returns>
+        Task WriteMetricPointAsync(byte[] name, byte[] flattenedLabels, CanonicalLabel canonicalLabel,
+            CancellationToken cancel, double value, byte[]? suffix = null);
 
         /// <summary>
         /// Flushes any pending buffers. Always call this after all your write calls.

--- a/Prometheus/Summary.cs
+++ b/Prometheus/Summary.cs
@@ -141,17 +141,17 @@ namespace Prometheus
                     }
                 }
 
-                await serializer.WriteIdentifierPartAsync(_parent.NameBytes, FlattenedLabelsBytes, cancel,
+                await serializer.WriteIdentifierPartAsync(Parent.NameBytes, FlattenedLabelsBytes, cancel,
                     postfix: SumLabelBytes);
                 await serializer.WriteValuePartAsync(sum, cancel);
-                await serializer.WriteIdentifierPartAsync(_parent.NameBytes, FlattenedLabelsBytes, cancel,
+                await serializer.WriteIdentifierPartAsync(Parent.NameBytes, FlattenedLabelsBytes, cancel,
                     postfix: CountLabelBytes);
                 await serializer.WriteValuePartAsync(count, cancel);
 
                 for (var i = 0; i < values.Count; i++)
                 {
                     await serializer.WriteIdentifierPartAsync(
-                        _parent.NameBytes, FlattenedLabelsBytes, cancel, postfix: null,
+                        Parent.NameBytes, FlattenedLabelsBytes, cancel, postfix: null,
                         extraLabelName: QuantileLabelBytes, extraLabelValue: _quantileLabels[i].Item1,
                         extraLabelValueOpenMetrics: _quantileLabels[i].Item2);
                     await serializer.WriteValuePartAsync(values[i].value, cancel);

--- a/Tests.NetCore/HistogramTests.cs
+++ b/Tests.NetCore/HistogramTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System.Threading.Tasks;
 
@@ -30,13 +31,12 @@ namespace Prometheus.Tests
             // 2.0
             // 3.0
             // +inf
-            await serializer.ReceivedWithAnyArgs(6).WriteIdentifierPartAsync(default,default, default);
-            await serializer.Received().WriteValuePartAsync(5.0, default);
-            await serializer.Received().WriteValuePartAsync(2.0, default);
-            await serializer.Received().WriteValuePartAsync(0, default);
-            await serializer.Received().WriteValuePartAsync(1, default);
-            await serializer.Received().WriteValuePartAsync(2, default);
-            await serializer.Received().WriteValuePartAsync(2, default);
+            await serializer.Received().WriteMetricPointAsync(Arg.Any<byte[]>(), Arg.Any<byte[]>(), Arg.Any<CanonicalLabel>(), Arg.Any<CancellationToken>(),5.0, Arg.Any<byte[]>());
+            await serializer.Received().WriteMetricPointAsync(Arg.Any<byte[]>(), Arg.Any<byte[]>(), Arg.Any<CanonicalLabel>(), Arg.Any<CancellationToken>(),2.0, Arg.Any<byte[]>());
+            await serializer.Received().WriteMetricPointAsync(Arg.Any<byte[]>(), Arg.Any<byte[]>(), Arg.Any<CanonicalLabel>(), Arg.Any<CancellationToken>(),0, Arg.Any<byte[]>());
+            await serializer.Received().WriteMetricPointAsync(Arg.Any<byte[]>(), Arg.Any<byte[]>(), Arg.Any<CanonicalLabel>(), Arg.Any<CancellationToken>(),1, Arg.Any<byte[]>());
+            await serializer.Received().WriteMetricPointAsync(Arg.Any<byte[]>(), Arg.Any<byte[]>(), Arg.Any<CanonicalLabel>(), Arg.Any<CancellationToken>(),2, Arg.Any<byte[]>());
+            await serializer.Received().WriteMetricPointAsync(Arg.Any<byte[]>(), Arg.Any<byte[]>(), Arg.Any<CanonicalLabel>(), Arg.Any<CancellationToken>(),2, Arg.Any<byte[]>());
         }
 
         [TestMethod]

--- a/Tests.NetCore/MetricInitializationTests.cs
+++ b/Tests.NetCore/MetricInitializationTests.cs
@@ -48,8 +48,7 @@ namespace Prometheus.Tests
             // Without touching any metrics, there should be output for all because default config publishes immediately.
 
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteIdentifierPartAsync(default, default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteValuePartAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
         }
 
         [TestMethod]
@@ -81,8 +80,7 @@ namespace Prometheus.Tests
 
             // There is a family for each of the above, in each family we expect to see 0 metrics.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteIdentifierPartAsync(default,default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync(default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
         }
 
         [TestMethod]
@@ -119,8 +117,7 @@ namespace Prometheus.Tests
 
             // Even though suppressed, they all now have values so should all be published.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteIdentifierPartAsync(default,default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteValuePartAsync( default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
         }
 
         [TestMethod]
@@ -157,8 +154,7 @@ namespace Prometheus.Tests
 
             // Even though suppressed, they were all explicitly published.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteIdentifierPartAsync(default, default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteValuePartAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
         }
         #endregion
 
@@ -184,8 +180,7 @@ namespace Prometheus.Tests
 
             // Metrics are published as soon as label values are defined.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteIdentifierPartAsync(default, default,default);
-            await serializer.ReceivedWithAnyArgs(9).WriteValuePartAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);;
         }
 
         [TestMethod]
@@ -217,7 +212,7 @@ namespace Prometheus.Tests
 
             // Publishing was suppressed.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync( default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
         }
 
         [TestMethod]
@@ -254,8 +249,7 @@ namespace Prometheus.Tests
 
             // Metrics are published because value was set.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteIdentifierPartAsync( default,default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteValuePartAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
         }
 
         [TestMethod]
@@ -292,8 +286,7 @@ namespace Prometheus.Tests
 
             // Metrics are published because of explicit publish.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteIdentifierPartAsync(default, default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteValuePartAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
         }
 
         [TestMethod]
@@ -311,7 +304,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(0).WriteValuePartAsync( default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
         }
         #endregion
 
@@ -336,7 +329,7 @@ namespace Prometheus.Tests
 
             // Family for each of the above, in each is 0 metrics.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync(default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
         }
 
         [TestMethod]
@@ -365,8 +358,7 @@ namespace Prometheus.Tests
 
             // Family for each of the above, in each is 4 metrics (labelled only).
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteIdentifierPartAsync( default, default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteValuePartAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
 
             // Only after touching unlabelled do they get published.
             gauge.Inc();
@@ -379,8 +371,7 @@ namespace Prometheus.Tests
 
             // Family for each of the above, in each is 8 metrics (unlabelled+labelled).
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9 * 2).WriteIdentifierPartAsync( default, default, default);
-            await serializer.ReceivedWithAnyArgs(9 * 2).WriteValuePartAsync( default, default);
+            await serializer.ReceivedWithAnyArgs(18).WriteMetricPointAsync(default, default, default, default, default);
         }
         #endregion
 

--- a/Tests.NetCore/MetricsTests.cs
+++ b/Tests.NetCore/MetricsTests.cs
@@ -71,12 +71,10 @@ namespace Prometheus.Tests
             await registry2.CollectAndSerializeAsync(serializer2, default);
 
             await serializer1.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default);
-            await serializer2.ReceivedWithAnyArgs().WriteIdentifierPartAsync(default,default, default);
-            await serializer1.ReceivedWithAnyArgs().WriteValuePartAsync( default, default);
+            await serializer1.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default);
 
             await serializer2.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default);
-            await serializer2.ReceivedWithAnyArgs().WriteIdentifierPartAsync(default, default, default);
-            await serializer2.ReceivedWithAnyArgs().WriteValuePartAsync( default, default);
+            await serializer2.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default);
         }
 
         [TestMethod]
@@ -92,7 +90,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync( default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
             serializer.ClearReceivedCalls();
 
             metric.Inc();
@@ -101,7 +99,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync(default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
         }
 
         [TestMethod]
@@ -119,7 +117,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync( default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
             serializer.ClearReceivedCalls();
 
             instance.Inc();
@@ -128,7 +126,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync(default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
         }
 
         [TestMethod]
@@ -146,8 +144,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(1).WriteIdentifierPartAsync(default,default, default);
-            await serializer.ReceivedWithAnyArgs(1).WriteValuePartAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteMetricPointAsync(default, default, default, default, default);
             serializer.ClearReceivedCalls();
 
             instance.Dispose();
@@ -155,8 +152,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
             
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteIdentifierPartAsync(default, default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteValuePartAsync( default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default);
         }
 
         [TestMethod]

--- a/Tests.NetCore/TextSerializerTests.cs
+++ b/Tests.NetCore/TextSerializerTests.cs
@@ -16,7 +16,11 @@ public class TextSerializerTests
         {
             var summary = factory.CreateSummary("boom_bam", "", new SummaryConfiguration
             {
-                LabelNames = new[] { "blah" }
+                LabelNames = new[] { "blah" },
+                Objectives = new[]
+                {
+                    new QuantileEpsilonPair(0.5, 0.05),
+                }
             });
 
             summary.WithLabels("foo").Observe(3);
@@ -26,8 +30,33 @@ public class TextSerializerTests
 # TYPE boom_bam summary
 boom_bam_sum{blah=""foo""} 3
 boom_bam_count{blah=""foo""} 1
+boom_bam{blah=""foo"",quantile=""0.5""} 3
 ");
     }
+
+    [TestMethod]
+    public async Task ValidateTextFmtSummaryExposition_HappyPath_NoLabels()
+    {
+        var result = await TestCase.Run(factory =>
+        {
+            var summary = factory.CreateSummary("boom_bam", "something", new SummaryConfiguration
+            {
+                Objectives = new[]
+                {
+                    new QuantileEpsilonPair(0.5, 0.05),
+                }
+            });
+            summary.Observe(3);
+        });
+        // TODO help has a trailing whitespace before the newline
+        result.ShouldBe(@"# HELP boom_bam something
+# TYPE boom_bam summary
+boom_bam_sum 3
+boom_bam_count 1
+boom_bam{quantile=""0.5""} 3
+");
+    }
+
 
     [TestMethod]
     public async Task ValidateTextFmtGaugeExposition_HappyPath()
@@ -63,24 +92,24 @@ boom_bam{blah=""foo""} 10
 
         // TODO help has a trailing whitespace before the newline
         result.ShouldBe("# HELP boom_bam \n" +
-"# TYPE boom_bam counter\n" +
-"boom_bam{blah=\"foo\"} 10\n");
+                        "# TYPE boom_bam counter\n" +
+                        "boom_bam{blah=\"foo\"} 10\n");
     }
-    
+
     [TestMethod]
     public async Task ValidateTextFmtHistogramExposition_HappyPath()
     {
         var result = await TestCase.Run(factory =>
         {
-            var counter = factory.CreateHistogram("boom_bam", "", new HistogramConfiguration 
+            var counter = factory.CreateHistogram("boom_bam", "", new HistogramConfiguration
             {
-                LabelNames = new [] {"blah"},
-                Buckets = new [] { 1.0 }
+                LabelNames = new[] { "blah" },
+                Buckets = new[] { 1.0 }
             });
 
             counter.WithLabels("foo").Observe(0.5);
         });
-        
+
         // TODO help has a trailing whitespace before the newline
         result.ShouldBe(@"# HELP boom_bam 
 # TYPE boom_bam histogram
@@ -90,7 +119,31 @@ boom_bam_bucket{blah=""foo"",le=""1""} 1
 boom_bam_bucket{blah=""foo"",le=""+Inf""} 1
 ");
     }
-    
+
+    [TestMethod]
+    public async Task ValidateTextFmtHistogramExposition_HappyPath_NoLabels()
+    {
+        var result = await TestCase.Run(factory =>
+        {
+            var counter = factory.CreateHistogram("boom_bam", "something", new HistogramConfiguration
+            {
+                Buckets = new[] { 1.0, 2 }
+            });
+
+            counter.Observe(0.5);
+        });
+
+        result.ShouldBe(@"# HELP boom_bam something
+# TYPE boom_bam histogram
+boom_bam_sum 0.5
+boom_bam_count 1
+boom_bam_bucket{le=""1""} 1
+boom_bam_bucket{le=""2""} 1
+boom_bam_bucket{le=""+Inf""} 1
+");
+    }
+
+
     private class TestCase
     {
         private readonly String raw;

--- a/Tests.NetCore/TextSerializerTests.cs
+++ b/Tests.NetCore/TextSerializerTests.cs
@@ -10,7 +10,7 @@ namespace Prometheus.Tests;
 public class TextSerializerTests
 {
     [TestMethod]
-    public async Task ValidateTextFmtSummaryExposition_HappyPath()
+    public async Task ValidateTextFmtSummaryExposition_Labels()
     {
         var result = await TestCase.Run(factory =>
         {
@@ -25,8 +25,8 @@ public class TextSerializerTests
 
             summary.WithLabels("foo").Observe(3);
         });
-        // TODO help has a trailing whitespace before the newline
-        result.ShouldBe(@"# HELP boom_bam 
+        
+        result.ShouldBe(@"# HELP boom_bam
 # TYPE boom_bam summary
 boom_bam_sum{blah=""foo""} 3
 boom_bam_count{blah=""foo""} 1
@@ -35,7 +35,7 @@ boom_bam{blah=""foo"",quantile=""0.5""} 3
     }
 
     [TestMethod]
-    public async Task ValidateTextFmtSummaryExposition_HappyPath_NoLabels()
+    public async Task ValidateTextFmtSummaryExposition_NoLabels()
     {
         var result = await TestCase.Run(factory =>
         {
@@ -48,7 +48,7 @@ boom_bam{blah=""foo"",quantile=""0.5""} 3
             });
             summary.Observe(3);
         });
-        // TODO help has a trailing whitespace before the newline
+        
         result.ShouldBe(@"# HELP boom_bam something
 # TYPE boom_bam summary
 boom_bam_sum 3
@@ -59,7 +59,7 @@ boom_bam{quantile=""0.5""} 3
 
 
     [TestMethod]
-    public async Task ValidateTextFmtGaugeExposition_HappyPath()
+    public async Task ValidateTextFmtGaugeExposition_Labels()
     {
         var result = await TestCase.Run(factory =>
         {
@@ -70,15 +70,15 @@ boom_bam{quantile=""0.5""} 3
 
             gauge.WithLabels("foo").IncTo(10);
         });
-        // TODO help has a trailing whitespace before the newline
-        result.ShouldBe(@"# HELP boom_bam 
+        
+        result.ShouldBe(@"# HELP boom_bam
 # TYPE boom_bam gauge
 boom_bam{blah=""foo""} 10
 ");
     }
 
     [TestMethod]
-    public async Task ValidateTextFmtCounterExposition_HappyPath()
+    public async Task ValidateTextFmtCounterExposition_Labels()
     {
         var result = await TestCase.Run(factory =>
         {
@@ -90,14 +90,13 @@ boom_bam{blah=""foo""} 10
             counter.WithLabels("foo").IncTo(10);
         });
 
-        // TODO help has a trailing whitespace before the newline
-        result.ShouldBe("# HELP boom_bam \n" +
+        result.ShouldBe("# HELP boom_bam\n" +
                         "# TYPE boom_bam counter\n" +
                         "boom_bam{blah=\"foo\"} 10\n");
     }
 
     [TestMethod]
-    public async Task ValidateTextFmtHistogramExposition_HappyPath()
+    public async Task ValidateTextFmtHistogramExposition_Labels()
     {
         var result = await TestCase.Run(factory =>
         {
@@ -110,8 +109,7 @@ boom_bam{blah=""foo""} 10
             counter.WithLabels("foo").Observe(0.5);
         });
 
-        // TODO help has a trailing whitespace before the newline
-        result.ShouldBe(@"# HELP boom_bam 
+        result.ShouldBe(@"# HELP boom_bam
 # TYPE boom_bam histogram
 boom_bam_sum{blah=""foo""} 0.5
 boom_bam_count{blah=""foo""} 1
@@ -121,7 +119,7 @@ boom_bam_bucket{blah=""foo"",le=""+Inf""} 1
     }
 
     [TestMethod]
-    public async Task ValidateTextFmtHistogramExposition_HappyPath_NoLabels()
+    public async Task ValidateTextFmtHistogramExposition_NoLabels()
     {
         var result = await TestCase.Run(factory =>
         {

--- a/Tests.NetFramework/tests.netframework.csproj
+++ b/Tests.NetFramework/tests.netframework.csproj
@@ -156,6 +156,9 @@
     <Compile Include="..\Tests.NetCore\TestExtensions.cs">
       <Link>TestExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Tests.NetCore\TextSerializerTests.cs">
+      <Link>TextSerializerTests.cs</Link>
+    </Compile>
     <Compile Include="..\Tests.NetCore\ThreadSafeDoubleTests.cs">
       <Link>ThreadSafeDoubleTests.cs</Link>
     </Compile>


### PR DESCRIPTION

The core of this PR is about moving the business logic of the `CreateIdentity` encoding function to the `TextSerializer` 

The granularity of memoization has changed. The system labels `le `and `quantile` have corner cases when using the OpenMetrics encoding. For example le="1" in the Prom text format should be encoded as le="1.0" in OpenMetrics. 

I wrote some tests before undertaking the refactor, I will build on these when building out the OpenMetrics support.

Pre-refactor benchmark:

|              Method |     Mean |    Error |   StdDev |     Gen0 | Allocated |
|-------------------- |---------:|---------:|---------:|---------:|----------:|
| CollectAndSerialize | 40.07 ms | 0.520 ms | 0.461 ms | 692.3077 |   5.91 MB |

Refactored benchmark:

|              Method |     Mean |    Error |   StdDev |     Gen0 | Allocated |
|-------------------- |---------:|---------:|---------:|---------:|----------:|
| CollectAndSerialize | 40.53 ms | 0.375 ms | 0.333 ms | 692.3077 |   5.91 MB |