### PR TITLE
Openmetrics encoding support and Exemplars.

### DIFF
--- a/Benchmark.NetCore/SerializationBenchmarks.cs
+++ b/Benchmark.NetCore/SerializationBenchmarks.cs
@@ -63,13 +63,14 @@ namespace Benchmark.NetCore
         [GlobalSetup]
         public void GenerateData()
         {
+            var exemplar = Exemplar.Key("traceID").WithValue("bar");
             for (var metricIndex = 0; metricIndex < _metricCount; metricIndex++)
                 for (var variantIndex = 0; variantIndex < _variantCount; variantIndex++)
                 {
-                    _counters[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Inc();
+                    _counters[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Inc(exemplar);
                     _gauges[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Inc();
                     _summaries[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Observe(variantIndex);
-                    _histograms[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Observe(variantIndex);
+                    _histograms[metricIndex].Labels(_labelValueRows[metricIndex][variantIndex]).Observe(variantIndex, exemplar);
                 }
         }
 
@@ -77,6 +78,12 @@ namespace Benchmark.NetCore
         public async Task CollectAndSerialize()
         {
             await _registry.CollectAndSerializeAsync(new TextSerializer(Stream.Null), default);
+        }
+        
+        [Benchmark]
+        public async Task CollectAndSerializeOpenMetrics()
+        {
+            await _registry.CollectAndSerializeAsync(new TextSerializer(Stream.Null, ExpositionFormat.OpenMetricsText), default);
         }
     }
 }

--- a/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
+++ b/Prometheus.AspNetCore/MetricServerMiddlewareExtensions.cs
@@ -16,7 +16,8 @@ namespace Prometheus
         public static IEndpointConventionBuilder MapMetrics(
             this IEndpointRouteBuilder endpoints,
             string pattern = "/metrics",
-            CollectorRegistry? registry = null
+            CollectorRegistry? registry = null,
+            bool enableOpenMetrics = false
         )
         {
             var pipeline = endpoints
@@ -24,6 +25,7 @@ namespace Prometheus
                 .UseMiddleware<MetricServerMiddleware>(
                     new MetricServerMiddleware.Settings
                     {
+                        EnableOpenMetrics = enableOpenMetrics,
                         Registry = registry
                     }
                 )
@@ -39,13 +41,14 @@ namespace Prometheus
         /// The default URL is /metrics, which is a Prometheus convention.
         /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
         /// </summary>
-        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, int port, string? url = "/metrics", CollectorRegistry? registry = null)
+        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, int port,
+            string? url = "/metrics", CollectorRegistry? registry = null, bool enableOpenMetrics = false)
         {
             // If no URL, use root URL.
             url ??= "/";
 
             return builder
-                .Map(url, b => b.MapWhen(PortMatches(), b1 => b1.InternalUseMiddleware(registry)));
+                .Map(url, b => b.MapWhen(PortMatches(), b1 => b1.InternalUseMiddleware(enableOpenMetrics, registry)));
 
             Func<HttpContext, bool> PortMatches()
             {
@@ -58,19 +61,21 @@ namespace Prometheus
         /// The default URL is /metrics, which is a Prometheus convention.
         /// Use static methods on the <see cref="Metrics"/> class to create your metrics.
         /// </summary>
-        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, string? url = "/metrics", CollectorRegistry? registry = null)
+        public static IApplicationBuilder UseMetricServer(this IApplicationBuilder builder, string? url = "/metrics",
+            CollectorRegistry? registry = null, bool enableOpenMetrics = false)
         {
             // If there is a URL to map, map it and re-enter without the URL.
             if (url != null)
-                return builder.Map(url, b => b.InternalUseMiddleware(registry));
+                return builder.Map(url, b => b.InternalUseMiddleware(enableOpenMetrics, registry));
             else
-                return builder.InternalUseMiddleware(registry);
+                return builder.InternalUseMiddleware(enableOpenMetrics, registry);
         }
 
-        private static IApplicationBuilder InternalUseMiddleware(this IApplicationBuilder builder, CollectorRegistry? registry = null)
+        private static IApplicationBuilder InternalUseMiddleware(this IApplicationBuilder builder, bool enableOpenMetrics, CollectorRegistry? registry = null)
         {
             return builder.UseMiddleware<MetricServerMiddleware>(new MetricServerMiddleware.Settings
             {
+                EnableOpenMetrics = enableOpenMetrics,
                 Registry = registry
             });
         }

--- a/Prometheus.NetFramework.AspNet/AspNetMetricServer.cs
+++ b/Prometheus.NetFramework.AspNet/AspNetMetricServer.cs
@@ -62,7 +62,7 @@ namespace Prometheus
                     {
                         try
                         {
-                            await _registry.CollectAndExportAsTextAsync(stream, cancellationToken);
+                            await _registry.CollectAndExportAsTextAsync(stream, ExpositionFormat.Text, cancellationToken);
                         }
                         finally
                         {

--- a/Prometheus/AutoLeasingCounter.cs
+++ b/Prometheus/AutoLeasingCounter.cs
@@ -39,6 +39,11 @@
 
             public double Value => throw new NotSupportedException("Read operations on a lifetime-extending-on-use expiring metric are not supported.");
 
+            public void Inc(params Exemplar.LabelPair[] exemplar)
+            {
+                Inc(increment:1, exemplar: exemplar);
+            }
+
             public void Inc(double increment = 1,  params Exemplar.LabelPair[] exemplar)
             {
                 _inner.WithLease(x => x.Inc(increment, exemplar), _labelValues);

--- a/Prometheus/AutoLeasingCounter.cs
+++ b/Prometheus/AutoLeasingCounter.cs
@@ -39,9 +39,9 @@
 
             public double Value => throw new NotSupportedException("Read operations on a lifetime-extending-on-use expiring metric are not supported.");
 
-            public void Inc(double increment = 1)
+            public void Inc(double increment = 1,  params Exemplar.LabelPair[] exemplar)
             {
-                _inner.WithLease(x => x.Inc(increment), _labelValues);
+                _inner.WithLease(x => x.Inc(increment, exemplar), _labelValues);
             }
 
             public void IncTo(double targetValue)

--- a/Prometheus/AutoLeasingHistogram.cs
+++ b/Prometheus/AutoLeasingHistogram.cs
@@ -45,9 +45,14 @@
                 _inner.WithLease(x => x.Observe(val, count), _labelValues);
             }
 
+            public void Observe(double val, params Exemplar.LabelPair[] exemplar)
+            {
+                _inner.WithLease(x => x.Observe(val, exemplar), _labelValues);
+            }
+
             public void Observe(double val)
             {
-                _inner.WithLease(x => x.Observe(val), _labelValues);
+                Observe(val, Array.Empty<Exemplar.LabelPair>());
             }
         }
     }

--- a/Prometheus/CollectorRegistry.cs
+++ b/Prometheus/CollectorRegistry.cs
@@ -136,12 +136,12 @@ namespace Prometheus
         /// 
         /// This method is designed to be used with custom output mechanisms that do not use an IMetricServer.
         /// </summary>
-        public Task CollectAndExportAsTextAsync(Stream to, CancellationToken cancel = default)
+        public Task CollectAndExportAsTextAsync(Stream to, ExpositionFormat format= ExpositionFormat.Text, CancellationToken cancel = default)
         {
             if (to == null)
                 throw new ArgumentNullException(nameof(to));
 
-            return CollectAndSerializeAsync(new TextSerializer(to), cancel);
+            return CollectAndSerializeAsync(new TextSerializer(to, format), cancel);
         }
 
         // We pass this thing to GetOrAdd to avoid allocating a collector or a closure.
@@ -248,7 +248,7 @@ namespace Prometheus
 
             foreach (var collector in _collectors.Values)
                 await collector.CollectAndSerializeAsync(serializer, cancel);
-
+            await serializer.WriteEnd(cancel);
             await serializer.FlushAsync(cancel);
         }
 

--- a/Prometheus/Counter.cs
+++ b/Prometheus/Counter.cs
@@ -27,6 +27,11 @@ namespace Prometheus
                     ex);
             }
 
+            public void Inc(params Exemplar.LabelPair[] exemplar)
+            {
+                Inc(increment: 1, exemplar: exemplar);
+            }
+
             public void Inc(double increment = 1.0, params Exemplar.LabelPair[] exemplar)
             {
                 if (increment < 0.0)
@@ -64,6 +69,11 @@ namespace Prometheus
 
         public void Publish() => Unlabelled.Publish();
         public void Unpublish() => Unlabelled.Unpublish();
+
+        public void Inc(params Exemplar.LabelPair[] exemplar)
+        {
+            Inc(increment: 1, exemplar: exemplar);
+        }
 
         public void Inc(double increment = 1, params Exemplar.LabelPair[] exemplar) =>
             Unlabelled.Inc(increment, exemplar);

--- a/Prometheus/Exemplar.cs
+++ b/Prometheus/Exemplar.cs
@@ -56,6 +56,9 @@ public static class Exemplar
     /// </summary>
     public static LabelKey Key(string key)
     {
+        if (string.IsNullOrEmpty(key))
+            throw new ArgumentException("empty key");
+        
         var si = new StringInfo(key);
         return new LabelKey(PrometheusConstants.ExportEncoding.GetBytes(key), si.LengthInTextElements);
     }

--- a/Prometheus/Exemplar.cs
+++ b/Prometheus/Exemplar.cs
@@ -1,0 +1,71 @@
+﻿using System.Globalization;
+
+namespace Prometheus;
+
+public static class Exemplar
+{
+    /// <summary>
+    /// An exemplar label key.
+    /// </summary>
+    public readonly struct LabelKey
+    {
+        internal LabelKey(byte[] key, int runeCount)
+        {
+            Bytes = key;
+            RuneCount = runeCount;
+        }
+
+        internal int RuneCount { get; }
+
+        internal byte[] Bytes { get; }
+
+        /// <summary>
+        /// Create a LabelPair once a value is available
+        /// </summary>
+        public LabelPair WithValue(string value)
+        {
+            // TODO find a way of counting runes without using the StringInfo. Or find a way of pooling these :cry:
+            // It is used in K as well.
+            var si = new StringInfo(value);
+            return new LabelPair(
+                Bytes,
+                PrometheusConstants.ExportEncoding.GetBytes(value),
+                RuneCount + si.LengthInTextElements);
+        }
+    }
+
+    /// <summary>
+    /// A single exemplar label pair in a form suitable for efficient serialization.
+    /// </summary>
+    public readonly struct LabelPair
+    {
+        internal LabelPair(byte[] keyBytes, byte[] valueBytes, int runeCount)
+        {
+            KeyBytes = keyBytes;
+            ValueBytes = valueBytes;
+            RuneCount = runeCount;
+        }
+
+        internal int RuneCount { get; }
+        internal byte[] KeyBytes { get; }
+        internal byte[] ValueBytes { get; }
+    }
+    
+    /// <summary>
+    /// Return an exemplar label key, this may be curried with a value to produce a LabelPair.
+    /// </summary>
+    public static LabelKey Key(string key)
+    {
+        var si = new StringInfo(key);
+        return new LabelKey(PrometheusConstants.ExportEncoding.GetBytes(key), si.LengthInTextElements);
+    }
+    
+    /// <summary>
+    /// Pair constructs a LabelPair, it is advisable to memoize a "Key" (eg: "traceID") and then to derive "LabelPair"s
+    /// from these.
+    /// </summary>
+    public static LabelPair Pair(string key, string value)
+    {
+        return Key(key).WithValue(value);
+    }
+}

--- a/Prometheus/ExpositionFormats.cs
+++ b/Prometheus/ExpositionFormats.cs
@@ -1,0 +1,13 @@
+﻿namespace Prometheus;
+
+public enum ExpositionFormat
+{
+    /// <summary>
+    /// The traditional prometheus exposition format.
+    /// </summary>
+    Text,
+    /// <summary>
+    /// The OpenMetrics text exposition format
+    /// </summary>
+    OpenMetricsText
+}

--- a/Prometheus/Gauge.cs
+++ b/Prometheus/Gauge.cs
@@ -14,7 +14,7 @@
             private protected override async Task CollectAndSerializeImplAsync(IMetricsSerializer serializer, CancellationToken cancel)
             {
                 await serializer.WriteMetricPointAsync(
-                    Parent.NameBytes, FlattenedLabelsBytes, CanonicalLabel.Empty, cancel, Value);
+                    Parent.NameBytes, FlattenedLabelsBytes, CanonicalLabel.Empty, cancel, Value, ObservedExemplar.Empty);
             }
 
             public void Inc(double increment = 1)

--- a/Prometheus/ICollectorRegistry.cs
+++ b/Prometheus/ICollectorRegistry.cs
@@ -12,6 +12,6 @@
         IEnumerable<KeyValuePair<string, string>> StaticLabels { get; }
         void SetStaticLabels(IDictionary<string, string> labels);
 
-        Task CollectAndExportAsTextAsync(Stream to, CancellationToken cancel = default);
+        Task CollectAndExportAsTextAsync(Stream to, ExpositionFormat format = ExpositionFormat.Text, CancellationToken cancel = default);
     }
 }

--- a/Prometheus/ICounter.cs
+++ b/Prometheus/ICounter.cs
@@ -2,7 +2,12 @@
 {
     public interface ICounter : ICollectorChild
     {
-        void Inc(double increment = 1);
+        /// <summary>
+        /// Increment a counter
+        /// </summary>
+        /// <param name="increment">The increment.</param>
+        /// <param name="exemplar">A set of labels representing an exemplar.</param>
+        void Inc(double increment = 1, params Exemplar.LabelPair[] exemplar);
         void IncTo(double targetValue);
         double Value { get; }
     }

--- a/Prometheus/ICounter.cs
+++ b/Prometheus/ICounter.cs
@@ -3,6 +3,11 @@
     public interface ICounter : ICollectorChild
     {
         /// <summary>
+        /// Increment a counter by 1.
+        /// </summary>
+        /// <param name="exemplar">A set of labels representing an exemplar.</param>
+        void Inc(params Exemplar.LabelPair[] exemplar);
+        /// <summary>
         /// Increment a counter
         /// </summary>
         /// <param name="increment">The increment.</param>

--- a/Prometheus/IHistogram.cs
+++ b/Prometheus/IHistogram.cs
@@ -12,6 +12,13 @@
         void Observe(double val, long count);
 
         /// <summary>
+        /// Observe an event with an exemplar
+        /// </summary>
+        /// <param name="val">Measured value.</param>
+        /// <param name="exemplar">A set of labels representing an exemplar</param>
+        void Observe(double val, params Exemplar.LabelPair[] exemplar);
+        
+        /// <summary>
         /// Gets the sum of all observed events.
         /// </summary>
         double Sum { get; }

--- a/Prometheus/IMetricsSerializer.cs
+++ b/Prometheus/IMetricsSerializer.cs
@@ -10,7 +10,8 @@
         /// <summary>
         /// Writes the lines that declare the metric family.
         /// </summary>
-        Task WriteFamilyDeclarationAsync(byte[][] headerLines, CancellationToken cancel);
+        Task WriteFamilyDeclarationAsync(string name, byte[] nameBytes, byte[] helpBytes, MetricType type,
+            byte[] typeBytes, CancellationToken cancel);
 
         /// <summary>
         /// Writes out a single metric point

--- a/Prometheus/IMetricsSerializer.cs
+++ b/Prometheus/IMetricsSerializer.cs
@@ -17,7 +17,7 @@
         /// </summary>
         /// <returns></returns>
         Task WriteMetricPointAsync(byte[] name, byte[] flattenedLabels, CanonicalLabel canonicalLabel,
-            CancellationToken cancel, double value, byte[]? suffix = null);
+            CancellationToken cancel, double value, ObservedExemplar exemplar, byte[]? suffix = null);
 
         /// <summary>
         /// Writes out terminal lines

--- a/Prometheus/IMetricsSerializer.cs
+++ b/Prometheus/IMetricsSerializer.cs
@@ -20,6 +20,11 @@
             CancellationToken cancel, double value, byte[]? suffix = null);
 
         /// <summary>
+        /// Writes out terminal lines
+        /// </summary>
+        Task WriteEnd(CancellationToken cancel);
+        
+        /// <summary>
         /// Flushes any pending buffers. Always call this after all your write calls.
         /// </summary>
         Task FlushAsync(CancellationToken cancel);

--- a/Prometheus/ObservedExemplar.cs
+++ b/Prometheus/ObservedExemplar.cs
@@ -1,0 +1,67 @@
+﻿namespace Prometheus;
+
+/// <summary>
+/// Internal representation of an Exemplar ready to be serialized.
+/// </summary>
+internal struct ObservedExemplar
+{
+    private const int MaxRunes = 128;
+    public static readonly ObservedExemplar Empty = new();
+
+    internal static INowProvder NowProvider = new RealNowProvider();
+
+    public Exemplar.LabelPair[]? Labels { get; private set; }
+    public double Val { get; private set; }
+    public double Timestamp { get; private set; }
+
+    public ObservedExemplar()
+    {
+        Labels = null;
+        Val = 0;
+        Timestamp = 0;
+    }
+
+   internal interface INowProvder
+    {
+        double Now();
+    }
+
+   private sealed class RealNowProvider : INowProvder
+   {
+       public double Now()
+       { 
+           return DateTimeOffset.Now.ToUnixTimeMilliseconds() / 1e3;
+       }
+   }
+    
+    public bool IsValid => Labels != null;
+
+    public void Update(Exemplar.LabelPair[] labels, double val)
+    {
+        var tally = 0;
+        for (var i = 0; i < labels.Length; i++)
+        {
+            tally += labels[i].RuneCount;
+            for (var j = 0; j < labels.Length; j++)
+            {
+                if (i == j) continue;
+                if (Equal(labels[i].KeyBytes, labels[j].KeyBytes))
+                    throw new ArgumentException("exemplar contains duplicate keys");
+            }
+        }
+
+        if (tally > MaxRunes)
+            throw new ArgumentException($"exemplar labels has {tally} runes, exceeding the limit of {MaxRunes}.");
+
+        Labels = labels;
+        Val = val;
+        Timestamp = NowProvider.Now();
+    }
+    
+    private static bool Equal(byte[] a, byte[] b)
+    {
+        var x = a.Length ^ b.Length;
+        for (var i = 0; i < a.Length && i < b.Length; ++i) x |= a[i] ^ b[i];
+        return x == 0;
+    }
+}

--- a/Prometheus/Prometheus.csproj
+++ b/Prometheus/Prometheus.csproj
@@ -45,6 +45,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Prometheus/PrometheusConstants.cs
+++ b/Prometheus/PrometheusConstants.cs
@@ -5,10 +5,14 @@ namespace Prometheus
 {
     public static class PrometheusConstants
     {
-        public const string ExporterContentType = "text/plain; version=0.0.4; charset=utf-8";
+        public const string
+            ExporterContentType = "text/plain; version=0.0.4; charset=utf-8",
+            OpenMetricsExporterContentType = "application/openmetrics-text; version=0.0.1; charset=utf-8";
 
         // ASP.NET requires a MediaTypeHeaderValue object
-        public static readonly MediaTypeHeaderValue ExporterContentTypeValue = MediaTypeHeaderValue.Parse(ExporterContentType);
+        public static readonly MediaTypeHeaderValue
+            ExporterContentTypeValue = MediaTypeHeaderValue.Parse(ExporterContentType),
+            OpenMetricsMediaTypeHeaderValue = MediaTypeHeaderValue.Parse(OpenMetricsExporterContentType);
 
         // Use UTF-8 encoding, but provide the flag to ensure the Unicode Byte Order Mark is never
         // pre-pended to the output stream.

--- a/Prometheus/PrometheusConstants.cs
+++ b/Prometheus/PrometheusConstants.cs
@@ -6,13 +6,18 @@ namespace Prometheus
     public static class PrometheusConstants
     {
         public const string
-            ExporterContentType = "text/plain; version=0.0.4; charset=utf-8",
-            OpenMetricsExporterContentType = "application/openmetrics-text; version=0.0.1; charset=utf-8";
+            TextFmtContentType = "text/plain",
+            OpenMetricsContentType = "application/openmetrics-text";
+        
+        public const string
+            ExporterContentType = TextFmtContentType + "; version=0.0.4; charset=utf-8",
+            ExporterOpenMetricsContentType = OpenMetricsContentType + "; version=0.0.1; charset=utf-8";
+        
 
         // ASP.NET requires a MediaTypeHeaderValue object
         public static readonly MediaTypeHeaderValue
             ExporterContentTypeValue = MediaTypeHeaderValue.Parse(ExporterContentType),
-            OpenMetricsMediaTypeHeaderValue = MediaTypeHeaderValue.Parse(OpenMetricsExporterContentType);
+            ExporterOpenMetricsContentTypeValue = MediaTypeHeaderValue.Parse(ExporterOpenMetricsContentType);
 
         // Use UTF-8 encoding, but provide the flag to ensure the Unicode Byte Order Mark is never
         // pre-pended to the output stream.

--- a/Prometheus/Summary.cs
+++ b/Prometheus/Summary.cs
@@ -148,6 +148,7 @@ namespace Prometheus
                     CanonicalLabel.Empty,
                     cancel, 
                     sum,
+                    ObservedExemplar.Empty,
                     suffix: SumSuffix);
                 await serializer.WriteMetricPointAsync(
                     Parent.NameBytes,
@@ -155,6 +156,7 @@ namespace Prometheus
                     CanonicalLabel.Empty,
                     cancel, 
                     count,
+                    ObservedExemplar.Empty,
                     suffix: CountSuffix);
 
                 for (var i = 0; i < values.Count; i++)
@@ -164,7 +166,8 @@ namespace Prometheus
                         FlattenedLabelsBytes,
                         _quantileLabels[i],
                         cancel, 
-                        values[i].value);
+                        values[i].value,
+                        ObservedExemplar.Empty);
                 }
             }
 

--- a/Prometheus/TextSerializer.cs
+++ b/Prometheus/TextSerializer.cs
@@ -169,7 +169,6 @@ namespace Prometheus
             await WriteValue(value, cancel);
             if (_fmt == ExpositionFormat.OpenMetricsText && exemplar.IsValid)
             {
-                await _stream.Value.WriteAsync(Space, 0, Space.Length, cancel);
                 await WriteExemplarAsync(cancel, exemplar);
             }
 

--- a/Prometheus/TextSerializer.cs
+++ b/Prometheus/TextSerializer.cs
@@ -15,20 +15,26 @@ namespace Prometheus
         private static readonly byte[] LeftBrace = { (byte)'{' };
         private static readonly byte[] RightBraceSpace = { (byte)'}', (byte)' ' };
         private static readonly byte[] Space = { (byte)' ' };
+        private static readonly byte[] SpaceHashSpaceLeftBrace = { (byte)' ', (byte)'#', (byte)' ', (byte)'{' };
         private static readonly byte[] PositiveInfinity = PrometheusConstants.ExportEncoding.GetBytes("+Inf");
-        private static readonly byte[] EofLine = PrometheusConstants.ExportEncoding.GetBytes("# EOF\n");
+        private static readonly byte[] NegativeInfinity = PrometheusConstants.ExportEncoding.GetBytes("-Inf");
+        private static readonly byte[] NotANumber = PrometheusConstants.ExportEncoding.GetBytes("NaN");
+        private static readonly byte[] PositiveOne = PrometheusConstants.ExportEncoding.GetBytes("1.0");
+        private static readonly byte[] Zero = PrometheusConstants.ExportEncoding.GetBytes("0.0");
+        private static readonly byte[] NegativeOne = PrometheusConstants.ExportEncoding.GetBytes("-1.0");
+        private static readonly byte[] EofNewLine = PrometheusConstants.ExportEncoding.GetBytes("# EOF\n");
 
-        public TextSerializer(Stream stream, ExpositionFormat text = ExpositionFormat.Text)
+        public TextSerializer(Stream stream, ExpositionFormat fmt = ExpositionFormat.Text)
         {
-            _text = text;
+            _fmt = fmt;
             _stream = new Lazy<Stream>(() => stream);
         }
 
         // Enables delay-loading of the stream, because touching stream in HTTP handler triggers some behavior.
         public TextSerializer(Func<Stream> streamFactory,
-            ExpositionFormat text = ExpositionFormat.Text)
+            ExpositionFormat fmt = ExpositionFormat.Text)
         {
-            _text = text;
+            _fmt = fmt;
             _stream = new Lazy<Stream>(streamFactory);
         }
 
@@ -56,18 +62,75 @@ namespace Prometheus
 
         public async Task WriteEnd(CancellationToken cancel)
         {
-            if (_text == ExpositionFormat.OpenMetricsText)
-            {
-                await _stream.Value.WriteAsync(EofLine, 0, EofLine.Length, cancel);
-            }
+            if (_fmt == ExpositionFormat.OpenMetricsText)
+                await _stream.Value.WriteAsync(EofNewLine, 0, EofNewLine.Length, cancel);
         }
 
         public async Task WriteMetricPointAsync(byte[] name, byte[] flattenedLabels, CanonicalLabel canonicalLabel,
-            CancellationToken cancel,
-            double value, byte[]? suffix = null)
+            CancellationToken cancel, double value, ObservedExemplar exemplar, byte[]? suffix = null)
         {
-            await WriteIdentifierPartAsync(name, flattenedLabels, cancel, canonicalLabel, suffix);
-            await WriteValuePartAsync(value, cancel);
+            await WriteIdentifierPartAsync(name, flattenedLabels, cancel, canonicalLabel, exemplar, suffix);
+            await WriteValuePartAsync(value, exemplar, cancel);
+        }
+
+        private async Task WriteExemplarAsync(CancellationToken cancel, ObservedExemplar exemplar)
+        {
+            await _stream.Value.WriteAsync(SpaceHashSpaceLeftBrace, 0, SpaceHashSpaceLeftBrace.Length, cancel);
+            for (var i = 0; i < exemplar.Labels!.Length; i++)
+            {
+                if (i > 0)
+                    await _stream.Value.WriteAsync(Comma, 0, Comma.Length, cancel);
+                await WriteLabel(exemplar.Labels[i].KeyBytes, exemplar.Labels[i].ValueBytes, cancel);
+            }
+
+            await _stream.Value.WriteAsync(RightBraceSpace, 0, RightBraceSpace.Length, cancel);
+            await WriteValue(exemplar.Val, cancel);
+            await _stream.Value.WriteAsync(Space, 0, Space.Length, cancel);
+            await WriteValue(exemplar.Timestamp, cancel);
+        }
+
+        private async Task WriteLabel(byte[] label, byte[] value, CancellationToken cancel)
+        {
+            await _stream.Value.WriteAsync(label, 0, label.Length, cancel);
+            await _stream.Value.WriteAsync(Equal, 0, Equal.Length, cancel);
+            await _stream.Value.WriteAsync(Quote, 0, Quote.Length, cancel);
+            await _stream.Value.WriteAsync(value, 0, value.Length, cancel);
+            await _stream.Value.WriteAsync(Quote, 0, Quote.Length, cancel);
+        }
+
+        private async Task WriteValue(double value, CancellationToken cancel)
+        {
+            if (_fmt == ExpositionFormat.OpenMetricsText)
+            {
+                switch (value)
+                {
+                    case 0:
+                        await _stream.Value.WriteAsync(Zero, 0, Zero.Length, cancel);
+                        return;
+                    case 1:
+                        await _stream.Value.WriteAsync(PositiveOne, 0, PositiveOne.Length, cancel);
+                        return;
+                    case -1:
+                        await _stream.Value.WriteAsync(NegativeOne, 0, NegativeOne.Length, cancel);
+                        return;
+                    case double.PositiveInfinity:
+                        await _stream.Value.WriteAsync(PositiveInfinity, 0, PositiveInfinity.Length, cancel);
+                        return;
+                    case double.NegativeInfinity:
+                        await _stream.Value.WriteAsync(NegativeInfinity, 0, NegativeInfinity.Length, cancel);
+                        return;
+                    case double.NaN:
+                        await _stream.Value.WriteAsync(NotANumber, 0, NotANumber.Length, cancel);
+                        return;
+                }
+            }
+
+            var valueAsString = value.ToString(CultureInfo.InvariantCulture);
+            if (_fmt == ExpositionFormat.OpenMetricsText && !valueAsString.Contains("."))
+                valueAsString += ".0";
+            var numBytes = PrometheusConstants.ExportEncoding
+                .GetBytes(valueAsString, 0, valueAsString.Length, _stringBytesBuffer, 0);
+            await _stream.Value.WriteAsync(_stringBytesBuffer, 0, numBytes, cancel);
         }
 
         // Reuse a buffer to do the UTF-8 encoding.
@@ -75,35 +138,30 @@ namespace Prometheus
         // https://github.com/dotnet/corefx/issues/28379
         // Size limit guided by https://stackoverflow.com/questions/21146544/what-is-the-maximum-length-of-double-tostringd
         private readonly byte[] _stringBytesBuffer = new byte[32];
-        private readonly ExpositionFormat _text;
+        private readonly ExpositionFormat _fmt;
 
         // 123.456
         // Note: Terminates with a NEWLINE
-        private async Task WriteValuePartAsync(double value, CancellationToken cancel)
+        private async Task WriteValuePartAsync(double value, ObservedExemplar exemplar, CancellationToken cancel)
         {
-            var valueAsString = value.ToString(CultureInfo.InvariantCulture);
-            var numBytes = PrometheusConstants.ExportEncoding
-                .GetBytes(valueAsString, 0, valueAsString.Length, _stringBytesBuffer, 0);
+            await WriteValue(value, cancel);
+            if (_fmt == ExpositionFormat.OpenMetricsText && exemplar.IsValid)
+            {
+                await _stream.Value.WriteAsync(Space, 0, Space.Length, cancel);
+                await WriteExemplarAsync(cancel, exemplar);
+            }
 
-            await _stream.Value.WriteAsync(_stringBytesBuffer, 0, numBytes, cancel);
             await _stream.Value.WriteAsync(NewLine, 0, NewLine.Length, cancel);
         }
-
-        // For the observer methods on the instruments --e.g., `Observe*` I am thinking of a polymorpohic override were
-        // an exemplar is captured as `params (string, string) exemplars`. This is then captured in a local `Examplar`
-        // class/struct along with additional fields (timestamp and value). 
-        // 
-        // I could create an interface to help us memoise the key of the exemplar up front but I think perhaps we should
-        // relly on a stringbuilder(In the `TextSerializer`) to construct the exemplar encoding, we can store the encoded
-        // bytes in the `Exemplar`for future scrape cycles, but perhaps this is overoptimising.
         
+
         /// <summary>
         /// Creates a metric identifier, with an optional name postfix and an optional extra label to append to the end.
         /// familyname_postfix{labelkey1="labelvalue1",labelkey2="labelvalue2"}
         /// Note: Terminates with a SPACE
         /// </summary>
         private async Task WriteIdentifierPartAsync(byte[] name, byte[] flattenedLabels, CancellationToken cancel,
-            CanonicalLabel canonicalLabel, byte[]? suffix = null)
+            CanonicalLabel canonicalLabel, ObservedExemplar observedExemplar, byte[]? suffix = null)
         {
             await _stream.Value.WriteAsync(name, 0, name.Length, cancel);
             if (suffix != null && suffix.Length > 0)
@@ -131,7 +189,7 @@ namespace Prometheus
                     await _stream.Value.WriteAsync(canonicalLabel.Name, 0, canonicalLabel.Name.Length, cancel);
                     await _stream.Value.WriteAsync(Equal, 0, Equal.Length, cancel);
                     await _stream.Value.WriteAsync(Quote, 0, Quote.Length, cancel);
-                    if (_text == ExpositionFormat.OpenMetricsText)
+                    if (_fmt == ExpositionFormat.OpenMetricsText)
                         await _stream.Value.WriteAsync(
                             canonicalLabel.OpenMetrics, 0, canonicalLabel.OpenMetrics.Length, cancel);
                     else

--- a/Sample.Web/Program.cs
+++ b/Sample.Web/Program.cs
@@ -53,7 +53,7 @@ app.UseEndpoints(endpoints =>
     // * metrics about requests handled by the web app (configured above)
     // * ASP.NET health check statuses (configured above)
     // * custom business logic metrics published by the SampleService class
-    endpoints.MapMetrics();
+    endpoints.MapMetrics(enableOpenMetrics:true);
 });
 
 app.Run();

--- a/Sample.Web/SampleService.cs
+++ b/Sample.Web/SampleService.cs
@@ -68,16 +68,18 @@ public sealed class SampleService : BackgroundService
 
         await Task.WhenAll(googleTask, microsoftTask);
 
+        var exemplar = Exemplar.Pair("traceID", "1234");
+        
         // Determine the winner and report the change in score.
         if (googleStopwatch.Elapsed < microsoftStopwatch.Elapsed)
         {
-            WinsByEndpoint.WithLabels(googleUrl).Inc();
-            LossesByEndpoint.WithLabels(microsoftUrl).Inc();
+            WinsByEndpoint.WithLabels(googleUrl).Inc(exemplar);
+            LossesByEndpoint.WithLabels(microsoftUrl).Inc(exemplar);
         }
         else if (googleStopwatch.Elapsed < microsoftStopwatch.Elapsed)
         {
-            WinsByEndpoint.WithLabels(microsoftUrl).Inc();
-            LossesByEndpoint.WithLabels(googleUrl).Inc();
+            WinsByEndpoint.WithLabels(microsoftUrl).Inc(exemplar);
+            LossesByEndpoint.WithLabels(googleUrl).Inc(exemplar);
         }
         else
         {
@@ -86,7 +88,7 @@ public sealed class SampleService : BackgroundService
 
         // Report the difference.
         var difference = Math.Abs(googleStopwatch.Elapsed.TotalSeconds - microsoftStopwatch.Elapsed.TotalSeconds);
-        Difference.Observe(difference);
+        Difference.Observe(difference, exemplar: exemplar);
 
         // We finished one iteration of the service's work.
         IterationCount.Inc();

--- a/Sample.Web/run_prometheus_scrape.sh
+++ b/Sample.Web/run_prometheus_scrape.sh
@@ -1,0 +1,19 @@
+﻿#!/bin/bash
+
+# Runs a prometheus scrape on an endpoint with exemplar storage enabled. localhost:9090 will take you to the prometheus 
+# ui for verification.
+
+cat <<EOF > prometheus.yml
+scrape_configs:
+  - job_name: 'prometheus-net'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['$1']
+EOF
+
+docker run --rm -it --name prometheus -p 9090:9090 \
+    -v $PWD/prometheus.yml:/etc/prometheus/prometheus.yml \
+    prom/prometheus \
+    --config.file=/etc/prometheus/prometheus.yml \
+    --log.level=debug \
+    --enable-feature=exemplar-storage

--- a/Tests.NetCore/MetricInitializationTests.cs
+++ b/Tests.NetCore/MetricInitializationTests.cs
@@ -48,7 +48,7 @@ namespace Prometheus.Tests
             // Without touching any metrics, there should be output for all because default config publishes immediately.
 
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
         [TestMethod]
@@ -80,7 +80,7 @@ namespace Prometheus.Tests
 
             // There is a family for each of the above, in each family we expect to see 0 metrics.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
         [TestMethod]
@@ -117,7 +117,7 @@ namespace Prometheus.Tests
 
             // Even though suppressed, they all now have values so should all be published.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
         [TestMethod]
@@ -154,7 +154,7 @@ namespace Prometheus.Tests
 
             // Even though suppressed, they were all explicitly published.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
         #endregion
 
@@ -180,7 +180,7 @@ namespace Prometheus.Tests
 
             // Metrics are published as soon as label values are defined.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);;
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);;
         }
 
         [TestMethod]
@@ -212,7 +212,7 @@ namespace Prometheus.Tests
 
             // Publishing was suppressed.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
         [TestMethod]
@@ -249,7 +249,7 @@ namespace Prometheus.Tests
 
             // Metrics are published because value was set.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
         [TestMethod]
@@ -286,7 +286,7 @@ namespace Prometheus.Tests
 
             // Metrics are published because of explicit publish.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
         [TestMethod]
@@ -304,7 +304,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
         #endregion
 
@@ -329,7 +329,7 @@ namespace Prometheus.Tests
 
             // Family for each of the above, in each is 0 metrics.
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
         [TestMethod]
@@ -358,7 +358,7 @@ namespace Prometheus.Tests
 
             // Family for each of the above, in each is 4 metrics (labelled only).
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
 
             // Only after touching unlabelled do they get published.
             gauge.Inc();
@@ -371,7 +371,7 @@ namespace Prometheus.Tests
 
             // Family for each of the above, in each is 8 metrics (unlabelled+labelled).
             await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(18).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(18).WriteMetricPointAsync(default, default, default, default, default, default);
         }
         #endregion
 

--- a/Tests.NetCore/MetricInitializationTests.cs
+++ b/Tests.NetCore/MetricInitializationTests.cs
@@ -47,7 +47,7 @@ namespace Prometheus.Tests
 
             // Without touching any metrics, there should be output for all because default config publishes immediately.
 
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
@@ -79,7 +79,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // There is a family for each of the above, in each family we expect to see 0 metrics.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
@@ -116,7 +116,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Even though suppressed, they all now have values so should all be published.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
@@ -153,7 +153,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Even though suppressed, they were all explicitly published.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
         #endregion
@@ -179,7 +179,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Metrics are published as soon as label values are defined.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);;
         }
 
@@ -211,7 +211,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Publishing was suppressed.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
@@ -248,7 +248,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Metrics are published because value was set.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
@@ -285,7 +285,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Metrics are published because of explicit publish.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
@@ -303,7 +303,7 @@ namespace Prometheus.Tests
             var serializer = Substitute.For<IMetricsSerializer>();
             await registry.CollectAndSerializeAsync(serializer, default);
 
-            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
         #endregion
@@ -328,7 +328,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Family for each of the above, in each is 0 metrics.
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
@@ -357,7 +357,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Family for each of the above, in each is 4 metrics (labelled only).
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(9).WriteMetricPointAsync(default, default, default, default, default, default);
 
             // Only after touching unlabelled do they get published.
@@ -370,7 +370,7 @@ namespace Prometheus.Tests
             await registry.CollectAndSerializeAsync(serializer, default);
 
             // Family for each of the above, in each is 8 metrics (unlabelled+labelled).
-            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(4).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(18).WriteMetricPointAsync(default, default, default, default, default, default);
         }
         #endregion

--- a/Tests.NetCore/MetricsTests.cs
+++ b/Tests.NetCore/MetricsTests.cs
@@ -71,10 +71,10 @@ namespace Prometheus.Tests
             await registry2.CollectAndSerializeAsync(serializer2, default);
 
             await serializer1.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default);
-            await serializer1.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default);
+            await serializer1.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default, default);
 
             await serializer2.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default);
-            await serializer2.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default);
+            await serializer2.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
         [TestMethod]
@@ -90,7 +90,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
             serializer.ClearReceivedCalls();
 
             metric.Inc();
@@ -99,7 +99,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
         [TestMethod]
@@ -117,7 +117,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
             serializer.ClearReceivedCalls();
 
             instance.Inc();
@@ -126,7 +126,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
 
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.ReceivedWithAnyArgs(1).WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteMetricPointAsync(default, default, default, default, default, default);
             serializer.ClearReceivedCalls();
 
             instance.Dispose();
@@ -152,7 +152,7 @@ namespace Prometheus.Tests
             await _registry.CollectAndSerializeAsync(serializer, default);
             
             await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
-            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default);
+            await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
         [TestMethod]

--- a/Tests.NetCore/MetricsTests.cs
+++ b/Tests.NetCore/MetricsTests.cs
@@ -70,10 +70,10 @@ namespace Prometheus.Tests
             var serializer2 = Substitute.For<IMetricsSerializer>();
             await registry2.CollectAndSerializeAsync(serializer2, default);
 
-            await serializer1.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default);
+            await serializer1.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer1.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default, default);
 
-            await serializer2.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default);
+            await serializer2.ReceivedWithAnyArgs().WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer2.ReceivedWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default, default);
         }
 
@@ -89,7 +89,7 @@ namespace Prometheus.Tests
             var serializer = Substitute.For<IMetricsSerializer>();
             await _registry.CollectAndSerializeAsync(serializer, default);
 
-            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
             serializer.ClearReceivedCalls();
 
@@ -98,7 +98,7 @@ namespace Prometheus.Tests
 
             await _registry.CollectAndSerializeAsync(serializer, default);
 
-            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
@@ -116,7 +116,7 @@ namespace Prometheus.Tests
             var serializer = Substitute.For<IMetricsSerializer>();
             await _registry.CollectAndSerializeAsync(serializer, default);
 
-            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
             serializer.ClearReceivedCalls();
 
@@ -125,7 +125,7 @@ namespace Prometheus.Tests
 
             await _registry.CollectAndSerializeAsync(serializer, default);
 
-            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default,default, default);
         }
 
@@ -143,7 +143,7 @@ namespace Prometheus.Tests
             var serializer = Substitute.For<IMetricsSerializer>();
             await _registry.CollectAndSerializeAsync(serializer, default);
 
-            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.ReceivedWithAnyArgs(1).WriteMetricPointAsync(default, default, default, default, default, default);
             serializer.ClearReceivedCalls();
 
@@ -151,7 +151,7 @@ namespace Prometheus.Tests
             
             await _registry.CollectAndSerializeAsync(serializer, default);
             
-            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default);
+            await serializer.ReceivedWithAnyArgs(1).WriteFamilyDeclarationAsync(default, default, default, default, default, default);
             await serializer.DidNotReceiveWithAnyArgs().WriteMetricPointAsync(default, default, default, default, default, default);
         }
 

--- a/Tests.NetCore/TextSerializerTests.cs
+++ b/Tests.NetCore/TextSerializerTests.cs
@@ -151,7 +151,7 @@ boom_bam_bucket{blah=""foo"",le=""+Inf""} 1
         {
             var counter = factory.CreateHistogram("boom_bam", "something", new HistogramConfiguration
             {
-                Buckets = new[] { 1.0, 2 }
+                Buckets = new[] { 1.0, Math.Pow(10, 45) }
             });
 
             counter.Observe(0.5);
@@ -162,7 +162,7 @@ boom_bam_bucket{blah=""foo"",le=""+Inf""} 1
 boom_bam_sum 0.5
 boom_bam_count 1
 boom_bam_bucket{le=""1""} 1
-boom_bam_bucket{le=""2""} 1
+boom_bam_bucket{le=""1e+45""} 1
 boom_bam_bucket{le=""+Inf""} 1
 ");
     }
@@ -200,23 +200,26 @@ boom_bam_bucket{le=""+Inf""} 2.0
         {
             var counter = factory.CreateHistogram("boom_bam", "something", new HistogramConfiguration
             {
-                Buckets = new[] { 1, 2.5, 3}
+                Buckets = new[] { 1, 2.5, 3, Math.Pow(10, 45)}
             });
 
             counter.Observe(1, Exemplar.Pair("traceID", "1"));
             counter.Observe(1.5, Exemplar.Pair("traceID", "2"));
             counter.Observe(4, Exemplar.Pair("traceID", "3"));
+            counter.Observe(Math.Pow(10,44), Exemplar.Pair("traceID", "4"));
         });
         
-        // This asserts histogram openmetrics form with exemplars
+        // This asserts histogram OpenMetrics form with exemplars and also using numbers which are large enough for
+        // scientific notation
         result.ShouldBe(@"# HELP boom_bam something
 # TYPE boom_bam histogram
-boom_bam_sum 6.5
-boom_bam_count 3.0
+boom_bam_sum 1e+44
+boom_bam_count 4.0
 boom_bam_bucket{le=""1.0""} 1.0 # {traceID=""1""} 1.0 1668779954.714
 boom_bam_bucket{le=""2.5""} 2.0 # {traceID=""2""} 1.5 1668779954.714
 boom_bam_bucket{le=""3.0""} 2.0
-boom_bam_bucket{le=""+Inf""} 3.0 # {traceID=""3""} 4.0 1668779954.714
+boom_bam_bucket{le=""1e+45""} 4.0 # {traceID=""4""} 1e+44 1668779954.714
+boom_bam_bucket{le=""+Inf""} 4.0
 # EOF
 ");
     }

--- a/Tests.NetCore/TextSerializerTests.cs
+++ b/Tests.NetCore/TextSerializerTests.cs
@@ -213,10 +213,10 @@ boom_bam_bucket{le=""+Inf""} 2.0
 # TYPE boom_bam histogram
 boom_bam_sum 6.5
 boom_bam_count 3.0
-boom_bam_bucket{le=""1.0""} 1.0  # {traceID=""1""} 1.0 1668779954.714
-boom_bam_bucket{le=""2.5""} 2.0  # {traceID=""2""} 1.5 1668779954.714
+boom_bam_bucket{le=""1.0""} 1.0 # {traceID=""1""} 1.0 1668779954.714
+boom_bam_bucket{le=""2.5""} 2.0 # {traceID=""2""} 1.5 1668779954.714
 boom_bam_bucket{le=""3.0""} 2.0
-boom_bam_bucket{le=""+Inf""} 3.0  # {traceID=""3""} 4.0 1668779954.714
+boom_bam_bucket{le=""+Inf""} 3.0 # {traceID=""3""} 4.0 1668779954.714
 # EOF
 ");
     }
@@ -237,7 +237,7 @@ boom_bam_bucket{le=""+Inf""} 3.0  # {traceID=""3""} 4.0 1668779954.714
         // This asserts that multi-labeled exemplars work as well not supplying a _total suffix in the counter name.
         result.ShouldBe(@"# HELP boom_bam
 # TYPE boom_bam unknown
-boom_bam{blah=""foo""} 1.0  # {traceID=""1234"",yaay=""4321""} 1.0 1668779954.714
+boom_bam{blah=""foo""} 1.0 # {traceID=""1234"",yaay=""4321""} 1.0 1668779954.714
 # EOF
 ");
     }
@@ -258,7 +258,7 @@ boom_bam{blah=""foo""} 1.0  # {traceID=""1234"",yaay=""4321""} 1.0 1668779954.71
         // This tests the shape of OpenMetrics when _total suffix is supplied
         result.ShouldBe(@"# HELP boom_bam
 # TYPE boom_bam counter
-boom_bam_total{blah=""foo""} 1.0  # {traceID=""1234"",yaay=""4321""} 1.0 1668779954.714
+boom_bam_total{blah=""foo""} 1.0 # {traceID=""1234"",yaay=""4321""} 1.0 1668779954.714
 # EOF
 ");
     }

--- a/Tests.NetCore/TextSerializerTests.cs
+++ b/Tests.NetCore/TextSerializerTests.cs
@@ -263,7 +263,7 @@ boom_bam_total{blah=""foo""} 1.0 # {traceID=""1234"",yaay=""4321""} 1.0 16687799
 ");
     }
 
-    private class TestNowProvider : ObservedExemplar.INowProvder
+    private class TestNowProvider : ObservedExemplar.INowProvider
     {
         public readonly double TestNow = 1668779954.714;
         public double Now()


### PR DESCRIPTION
This PR:

* Introduces all of the machinery needed to attach an Exemplar to Counter and Histgram instruments.
* Openmetrics encoding - aim to have feature parity with the Golang implementation ([this PR](https://github.com/prometheus/common/commit/3888f9a53d4582c8b524af4acfdee6af64bedf07)).
* Protocol negotiation to select encoding format (manually tested with curl and verified with prometheus).
* Wired up end to end in ASP.net (please let me know if I have missed other ways of starting a HTTP runloop).
* Bash script to setup prom for scraping and ingesting exemplars for manual testing.

State: Feature complete.