### PR TITLE
[bug] fix MeterAdapter System.FormatException: Input string was not in a co…

### DIFF
--- a/Prometheus/MeterAdapter.cs
+++ b/Prometheus/MeterAdapter.cs
@@ -264,7 +264,7 @@ public sealed class MeterAdapter : IDisposable
         var sb = new StringBuilder();
 
         if (!string.IsNullOrWhiteSpace(instrument.Unit))
-            sb.AppendFormat($"({instrument.Unit}) ");
+            sb.Append($"({instrument.Unit}) ");
 
         sb.Append(instrument.Description);
 


### PR DESCRIPTION
It's probably just a typo. But the problem is blocking. 
Here [prometheus-net-dotpulsar](https://github.com/cyberline-engineering/prometheus-net-dotpulsar) is an example to reproduce the error.

When you create a custom Meter specifying a unit, such as this:
``` C#
m = new Meter("prometheus-dotpulsar", "1.0.0");
_ = m.CreateObservableGauge("dotpulsar.client.count", Inc, "{clients}", "Number of clients");
```
an unhandled exception occurs in the `TranslateInstrumentDescriptionToPrometheusHelp` method of the `MeterAdapter` class

https://github.com/prometheus-net/prometheus-net/blob/43b8625cc11a65430c72113242bf21507999771c/Prometheus/MeterAdapter.cs#L267

``` C#
System.FormatException: Input string was not in a correct format.
   at System.ThrowHelper.ThrowFormatInvalidString()
Exception thrown: 'System.FormatException' in System.Private.CoreLib.dll
System.FormatException: Input string was not in a correct format.
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at System.Text.StringBuilder.AppendFormat(String format, Object[] args)
   at Prometheus.MeterAdapter.TranslateInstrumentDescriptionToPrometheusHelp(Instrument instrument)
   at Prometheus.MeterAdapter.OnInstrumentPublished(Instrument instrument, MeterListener listener)
   at System.Diagnostics.Metrics.MeterListener.Start()
   at Prometheus.MeterAdapter..ctor(MeterAdapterOptions options)
   at Prometheus.MeterAdapter.StartListening(MeterAdapterOptions options)
   at Prometheus.SuppressDefaultMetricOptions.Configure(CollectorRegistry registry, ConfigurationCallbacks configurationCallbacks)
   at Prometheus.Metrics.<>c__DisplayClass23_0.<SuppressDefaultMetrics>b__0()
   at Prometheus.CollectorRegistry.CollectAndSerializeAsync(IMetricsSerializer serializer, CancellationToken cancel)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
```