### PR TITLE
Reduce allocations of TextSerializer 

### DIFF
--- a/Prometheus/Histogram.cs
+++ b/Prometheus/Histogram.cs
@@ -52,9 +52,13 @@ public sealed class Histogram : Collector<Histogram.Child>, IHistogram
             _upperBounds = Parent._buckets;
             _bucketCounts = new ThreadSafeLong[_upperBounds.Length];
             _leLabels = new CanonicalLabel[_upperBounds.Length];
+
+            // create a reusable buffer outside of the loop to avoid double-to-bytes intermediary string allocations
+            Span<byte> buffer = stackalloc byte[32];
+
             for (var i = 0; i < Parent._buckets.Length; i++)
             {
-                _leLabels[i] = TextSerializer.EncodeValueAsCanonicalLabel(LeLabelName, Parent._buckets[i]);
+                _leLabels[i] = TextSerializer.EncodeValueAsCanonicalLabel(LeLabelName, Parent._buckets[i], buffer);
             }
             _exemplars = new ObservedExemplar[_upperBounds.Length];
             for (var i = 0; i < _upperBounds.Length; i++)

--- a/Prometheus/Summary.cs
+++ b/Prometheus/Summary.cs
@@ -94,11 +94,15 @@ namespace Prometheus
                 _headStream = _streams[0];
 
                 _quantileLabels = new CanonicalLabel[_objectives.Count];
+
+                // create a reusable buffer outside of the loop to avoid double-to-bytes intermediary string allocations
+                Span<byte> buffer = stackalloc byte[32];
+
                 for (var i = 0; i < _objectives.Count; i++)
                 {
                     _sortedObjectives[i] = _objectives[i].Quantile;
                     _quantileLabels[i] = TextSerializer.EncodeValueAsCanonicalLabel(
-                        QuantileLabelName, _objectives[i].Quantile);
+                        QuantileLabelName, _objectives[i].Quantile, buffer);
                 }
 
                 Array.Sort(_sortedObjectives);


### PR DESCRIPTION
This PR reduces the allocations of TextSerializer by converting double/long values to byte arrays via intermediary buffers instead of creating intermediary strings. It does this by taking advantage of UftFormatters from the System.Memory assembly. All unit tests continue to pass as expected.

SerializationBenchmarks showed a 50% allocation reduction for CollectAndSerialize, while it brought CollectAndSerializeOpenMetrics down 66% into alignment with CollectAndSerialize. Since the runs of both benchmarks are bimodal, runtimes are difficult to compare although in my tests, they were unchanged and/or showed no significant differences. 

Existing:
``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19043.1826/21H1/May2021Update)
Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.201
  [Host]  : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
  LongRun : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2

Job=LongRun  IterationCount=100  LaunchCount=3  
WarmupCount=15  

```
|                         Method |      Mean |    Error |   StdDev |    Median |     Gen0 | Allocated |
|------------------------------- |----------:|---------:|---------:|----------:|---------:|----------:|
|            CollectAndSerialize | 104.09 ms | 3.845 ms | 19.77 ms | 102.44 ms | 428.5714 |   2.07 MB |
| CollectAndSerializeOpenMetrics |  99.72 ms | 4.825 ms | 24.37 ms |  86.99 ms | 500.0000 |   2.94 MB |


Optimized:

``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19043.1826/21H1/May2021Update)
Intel Core i7-8565U CPU 1.80GHz (Whiskey Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.201
  [Host]  : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
  LongRun : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2

Job=LongRun  IterationCount=100  LaunchCount=3  
WarmupCount=15  

```
|                         Method |     Mean |    Error |   StdDev |     Gen0 | Allocated |
|------------------------------- |---------:|---------:|---------:|---------:|----------:|
|            CollectAndSerialize | 95.12 ms | 3.763 ms | 18.97 ms | 200.0000 |   1.01 MB |
| CollectAndSerializeOpenMetrics | 94.29 ms | 4.322 ms | 22.22 ms | 250.0000 |   1.01 MB |

NOTE: there are potential opportunities to use UTF8 literals in other places to minimize allocations on startup, but that seems like a separate effort.