### PR TITLE
Implement IEquatable to avoid boxing in dictionary lookups

### DIFF
--- a/Prometheus/LabelSequence.cs
+++ b/Prometheus/LabelSequence.cs
@@ -5,7 +5,7 @@ namespace Prometheus;
 /// <summary>
 /// A sequence of metric label-name pairs.
 /// </summary>
-internal struct LabelSequence
+internal readonly struct LabelSequence : IEquatable<LabelSequence>
 {
     public static readonly LabelSequence Empty = new();
 


### PR DESCRIPTION
**Before:**

```
|                              Method |          Mean |       Error |     StdDev |   Gen0 | Allocated |
|------------------------------------ |--------------:|------------:|-----------:|-------:|----------:|
|   WithoutLabels_OneMetric_OneSeries |      6.480 ns |   0.0192 ns |  0.0180 ns |      - |         - |
| WithoutLabels_ManyMetrics_OneSeries |     65.623 ns |   0.1777 ns |  0.1662 ns |      - |         - |
|      WithLabels_OneMetric_OneSeries |    173.564 ns |   0.9192 ns |  0.8599 ns | 0.0045 |      72 B |
|     WithLabels_OneMetric_ManySeries |  1,712.560 ns |   6.7220 ns |  6.2878 ns | 0.0458 |     720 B |
|    WithLabels_ManyMetrics_OneSeries |  1,691.170 ns |   4.0042 ns |  3.5496 ns | 0.0458 |     720 B |
|   WithLabels_ManyMetrics_ManySeries | 17,494.907 ns | 101.7407 ns | 95.1683 ns | 0.4578 |    7200 B |
```

**After:**

```
|                              Method |          Mean |      Error |     StdDev | Allocated |
|------------------------------------ |--------------:|-----------:|-----------:|----------:|
|   WithoutLabels_OneMetric_OneSeries |      6.639 ns |  0.0735 ns |  0.0574 ns |         - |
| WithoutLabels_ManyMetrics_OneSeries |     67.139 ns |  0.3534 ns |  0.2951 ns |         - |
|      WithLabels_OneMetric_OneSeries |    159.396 ns |  0.6728 ns |  0.5618 ns |         - |
|     WithLabels_OneMetric_ManySeries |  1,584.690 ns |  4.0555 ns |  3.7935 ns |         - |
|    WithLabels_ManyMetrics_OneSeries |  1,577.203 ns |  4.1857 ns |  3.9154 ns |         - |
|   WithLabels_ManyMetrics_ManySeries | 16,169.908 ns | 76.2480 ns | 71.3224 ns |         - |
```