### PR TITLE
Add MeterAdapter support for .NET 8 static meter/instrument tags.

### DIFF
--- a/Prometheus/Prometheus.csproj
+++ b/Prometheus/Prometheus.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net462;net6.0;net7.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net462;net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Sample.Console.DotNetMeters/CustomDotNetMeters.cs
+++ b/Sample.Console.DotNetMeters/CustomDotNetMeters.cs
@@ -8,7 +8,7 @@ public static class CustomDotNetMeters
     public static void PublishSampleData()
     {
         // The meter object is the "container" for all the .NET metrics we will be publishing.
-        var meter1 = new Meter("Foobar.Wingwang.Dingdong", "vNext");
+        var meter1 = new Meter("Foobar.Wingwang.Dingdong", "vNext", tags: [new KeyValuePair<string, object?>("foo", "bar")]);
 
         // Example metric: a simple counter.
         var counter1 = meter1.CreateCounter<int>("wings-wanged", "wings", "Counts the number of wings that have been wanged.");
@@ -46,7 +46,7 @@ public static class CustomDotNetMeters
         var upDown2 = meter1.CreateObservableUpDownCounter<int>("sand-level", MeasureSandLevel, "chainlinks", "Current sand level in the tank (measured in visible chain links from the midpoint).");
 
         // Example high cardinality metric: bytes sent per connection.
-        var highCardinalityCounter1 = meter1.CreateCounter<long>("bytes-sent", "bytes", "Bytes sent per connection.");
+        var highCardinalityCounter1 = meter1.CreateCounter<long>("bytes-sent", "bytes", "Bytes sent per connection.", tags: [new KeyValuePair<string, object?>("connected", "false")]);
 
         var activeConnections = new List<Guid>();
 

--- a/Sample.Console.DotNetMeters/Sample.Console.DotNetMeters.csproj
+++ b/Sample.Console.DotNetMeters/Sample.Console.DotNetMeters.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Tests.NetCore/Tests.NetCore.csproj
+++ b/Tests.NetCore/Tests.NetCore.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+		<LangVersion>12</LangVersion>
 
 		<IsPackable>false</IsPackable>
 


### PR DESCRIPTION
These tags are set on the meter and/or instrument at creation time, and are automatically added to the measurements' labels.

This required a little bit of internal reworking of MeterAdapter so that the static label values are stored into the metric context. I re-organized the code of OnMeasurementRecorded to re-use code between the metric types better, as I had to move the label value pool fetch to be gotten AFTER the metric context.

Added a target framework for .NET 8, since we obviously need it for the new feature. I multi-targeted the tests to both .NET 7 and .NET 8 to make sure I didn't break anything.

Added these to the example and wrote tests for them too.