### PR TITLE
Avoid allocations for single label value

### DIFF
--- a/Benchmark.NetCore/MetricLookupBenchmarks.cs
+++ b/Benchmark.NetCore/MetricLookupBenchmarks.cs
@@ -38,6 +38,7 @@ public class MetricLookupBenchmarks
 
     private readonly CollectorRegistry _registry = Metrics.NewCustomRegistry();
     private readonly Counter[] _metrics;
+    private readonly Counter _singleLabelMetric;
 
     public MetricLookupBenchmarks()
     {
@@ -48,6 +49,8 @@ public class MetricLookupBenchmarks
         // Just use 1st variant for the keys (all we care about are that there is some name-like value in there).
         for (var metricIndex = 0; metricIndex < _metricCount; metricIndex++)
             _metrics[metricIndex] = factory.CreateCounter($"metric{metricIndex:D2}", "", _labelValueRows[metricIndex][0]);
+
+        _singleLabelMetric = factory.CreateCounter("single_label_metric", "", "label0");
     }
 
     /// <summary>
@@ -79,13 +82,33 @@ public class MetricLookupBenchmarks
     }
 
     /// <summary>
+    /// Increments a labelled Collector.Child instance for a single metric.
+    /// </summary>
+    [Benchmark]
+    public void WithLabels_OneMetric_ManySeries_OneLabel()
+    {
+        for (var variantIndex = 0; variantIndex < _variantCount; variantIndex++)
+            _singleLabelMetric.WithLabels(_labelValueRows[0][variantIndex][0]).Inc();
+    }
+
+    /// <summary>
+    /// Increments a labelled Collector.Child instance for a single metric.
+    /// </summary>
+    [Benchmark]
+    public void WithLabel_OneMetric_ManySeries_OneLabel()
+    {
+        for (var variantIndex = 0; variantIndex < _variantCount; variantIndex++)
+            _singleLabelMetric.WithLabel(_labelValueRows[0][variantIndex][0]).Inc();
+    }
+
+    /// <summary>
     /// Increments labelled Collector.Child instances for one metric with multiple different sets of labels.
     /// </summary>
     [Benchmark]
     public void WithLabels_OneMetric_ManySeries()
     {
         for (var variantIndex = 0; variantIndex < _variantCount; variantIndex++)
-            _metrics[0].WithLabels(_labelValueRows[0][variantIndex]).Inc();
+            _metrics[0].WithLabels(_labelValueRows[0][variantIndex][0]).Inc();
     }
 
     /// <summary>

--- a/Benchmark.NetCore/MetricLookupBenchmarks.cs
+++ b/Benchmark.NetCore/MetricLookupBenchmarks.cs
@@ -108,7 +108,7 @@ public class MetricLookupBenchmarks
     public void WithLabels_OneMetric_ManySeries()
     {
         for (var variantIndex = 0; variantIndex < _variantCount; variantIndex++)
-            _metrics[0].WithLabels(_labelValueRows[0][variantIndex][0]).Inc();
+            _metrics[0].WithLabels(_labelValueRows[0][variantIndex]).Inc();
     }
 
     /// <summary>

--- a/Prometheus/Collector.cs
+++ b/Prometheus/Collector.cs
@@ -191,10 +191,12 @@ public abstract class Collector<TChild> : Collector, ICollector<TChild>
         if (labelValue == null)
             throw new ArgumentNullException(nameof(labelValue));
 
-#if NET
-        // Calling a params method allocates an array. We can avoid that by calling the span overload directly.
-        var labelSpan = MemoryMarshal.CreateReadOnlySpan(ref labelValue, 1);
-        return WithLabels(labelSpan);
+    // Calling a params method allocates an array. We can avoid that by calling the span overload directly.
+    // The APIs for creating spans from single items are not available in .NET Framework, though.
+#if NET7_0_OR_GREATER
+        return WithLabels(new ReadOnlySpan<string>(in labelValue));
+#elif NET
+        return WithLabels(MemoryMarshal.CreateReadOnlySpan(ref labelValue, 1));
 #else
         return WithLabels(labelValue);
 #endif

--- a/Tests.NetCore/MetricsTests.cs
+++ b/Tests.NetCore/MetricsTests.cs
@@ -421,4 +421,18 @@ public sealed class MetricsTests
 
         Assert.AreEqual(0, values.Length);
     }
+
+    [TestMethod]
+    public void SingleLabel() {
+        var metric = _metrics.CreateGauge("single_label_metric", "", "label_name");
+
+        var labelled = metric.WithLabel("value1");
+
+        labelled.Inc(123);
+        metric.WithLabel("another_value").Inc(456);
+
+        Assert.AreEqual(123, labelled.Value);
+        Assert.AreSame(labelled, metric.WithLabel("value1"));
+        Assert.AreSame(labelled, metric.WithLabels("value1"));
+    }
 }


### PR DESCRIPTION
One of the ``WithLabels`` overloads uses a params argument. Calling a method with a single value for a params argument allocates memory, and I suspect that using a single label is quite common.

This change will prevent that for the common scenario of having only one label, by introducing a non-allocating method.

### Benchmark results
```
| Method                                   | Mean       | Error   | StdDev  | Allocated |
|----------------------------------------- |-----------:|--------:|--------:|----------:|
| WithLabels_OneMetric_ManySeries_OneLabel | 1,046.9 ns | 4.94 ns | 4.12 ns |     320 B |
| WithLabel_OneMetric_ManySeries_OneLabel  |   984.5 ns | 5.13 ns | 4.80 ns |         - |
```