### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/Prometheus/TextSerializer.Net.cs
+++ b/Prometheus/TextSerializer.Net.cs
@@ -570,7 +570,7 @@ internal sealed class TextSerializer : IMetricsSerializer
     /// <summary>
     /// Encode the special variable in regular Prometheus form and also return a OpenMetrics variant, these can be
     /// the same.
-    /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#considerations-canonical-numbers
+    /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#considerations-canonical-numbers
     /// </summary>
     internal static CanonicalLabel EncodeValueAsCanonicalLabel(byte[] name, double value)
     {

--- a/Prometheus/TextSerializer.NetStandardFx.cs
+++ b/Prometheus/TextSerializer.NetStandardFx.cs
@@ -291,7 +291,7 @@ internal sealed class TextSerializer : IMetricsSerializer
     /// <summary>
     /// Encode the special variable in regular Prometheus form and also return a OpenMetrics variant, these can be
     /// the same.
-    /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#considerations-canonical-numbers
+    /// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#considerations-canonical-numbers
     /// </summary>
     internal static CanonicalLabel EncodeValueAsCanonicalLabel(byte[] name, double value)
     {


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.