### PR TITLE
perf: replace object locks with SemaphoreSlim for improved performance in high concurrent scenarios

### DIFF
--- a/Prometheus/Summary.cs
+++ b/Prometheus/Summary.cs
@@ -164,9 +164,11 @@ public sealed class Summary : Collector<Summary.Child>, ISummary
 
             try
             {
-                lock (_bufLock)
+                _bufLock.Wait();
+                try
                 {
-                    lock (_lock)
+                    _lock.Wait();
+                    try
                     {
                         // Swap bufs even if hotBuf is empty to set new hotBufExpTime.
                         SwapBufs(now);
@@ -183,6 +185,14 @@ public sealed class Summary : Collector<Summary.Child>, ISummary
                             values[valuesIndex++] = (quantile, value);
                         }
                     }
+                    finally
+                    {
+                        _lock.Release();
+                    }
+                }
+                finally
+                {
+                    _bufLock.Release();
                 }
 
                 await serializer.WriteMetricPointAsync(
@@ -232,11 +242,11 @@ public sealed class Summary : Collector<Summary.Child>, ISummary
         private double _hotBufExpUnixtimeSeconds;
 
         // Protects hotBuf and hotBufExpTime.
-        private readonly object _bufLock = new();
+        private readonly SemaphoreSlim _bufLock = new(1, 1);
 
         // Protects every other moving part.
         // Lock bufMtx before mtx if both are needed.
-        private readonly object _lock = new();
+        private readonly SemaphoreSlim  _lock = new(1, 1);
 
         public void Observe(double val)
         {
@@ -251,8 +261,10 @@ public sealed class Summary : Collector<Summary.Child>, ISummary
             if (double.IsNaN(val))
                 return;
 
-            lock (_bufLock)
+            
+            try
             {
+                _bufLock.Wait();
                 if (nowUnixtimeSeconds > _hotBufExpUnixtimeSeconds)
                     Flush(nowUnixtimeSeconds);
 
@@ -261,6 +273,10 @@ public sealed class Summary : Collector<Summary.Child>, ISummary
                 if (_hotBuf.IsFull)
                     Flush(nowUnixtimeSeconds);
             }
+            finally
+            {
+                _bufLock.Release();
+            }
 
             Publish();
         }
@@ -268,13 +284,18 @@ public sealed class Summary : Collector<Summary.Child>, ISummary
         // Flush needs bufMtx locked.
         private void Flush(double nowUnixtimeSeconds)
         {
-            lock (_lock)
+            try
             {
+                _lock.Wait();
                 SwapBufs(nowUnixtimeSeconds);
 
                 // Go version flushes on a separate goroutine, but doing this on another
                 // thread actually makes the benchmark tests slower in .net
                 FlushColdBuf();
+            }
+            finally
+            {
+                _lock.Release();
             }
         }
 


### PR DESCRIPTION
### Description
Our team extensively uses `Summary` because it provides more accurate results than `Histogram` and puts less pressure on the database. The additional CPU/Memory cost is relatively low.

However, we recently noticed that under high-concurrency scenarios, the `lock` in `Summary.Observe` causes thread contention and significantly increases CPU usage. A simple fix is to replace it with `SemaphoreSlim.Wait`.

While `SemaphoreSlim.Wait` is still synchronous, it first spins for a short period instead of directly entering a kernel-mode wait, unlike `lock`. Since `Summary.Observe` itself is very fast, using `SemaphoreSlim.Wait` can significantly reduce kernel-mode waits. This means we can observe the same amount of data within the same time frame but with much lower CPU consumption.

Additionally, if we use `SemaphoreSlim.WaitAsync`, we can observe even more data in high-concurrency scenarios while further reducing CPU usage. No harms on sequential execution too.

---

### Testing
CPU usage cannot be measured using `dotnet benchmark`, so here is a dummy test code:

```csharp
using System.Diagnostics;
using Prometheus;

namespace PrometheusSummaryTest
{
    public class SemaphoreSummaryWrapper
    {
        private readonly Summary _summary;
        private readonly SemaphoreSlim _semaphore;

        public SemaphoreSummaryWrapper(Summary summary)
        {
            _summary = summary;
            _semaphore = new SemaphoreSlim(1, 1);
        }

        public void Observe(string label, double value)
        {
            _semaphore.Wait();
            try
            {
                _summary.WithLabels(label).Observe(value);
            }
            finally
            {
                _semaphore.Release();
            }
        }
    }

    public class SemaphoreSummaryWrapperAsync
    {
        private readonly Summary _summary;
        private readonly SemaphoreSlim _semaphore;

        public SemaphoreSummaryWrapperAsync(Summary summary)
        {
            _summary = summary;
            _semaphore = new SemaphoreSlim(1, 1);
        }

        public async Task ObserveAsync(string label, double value)
        {
            await _semaphore.WaitAsync();
            try
            {
                _summary.WithLabels(label).Observe(value);
            }
            finally
            {
                _semaphore.Release();
            }
        }
    }

    class Program
    {
        static async Task Main(string[] args)
        {
            var summary = Metrics.CreateSummary("summary", "Summary using wrapper",
                new SummaryConfiguration
                {
                    LabelNames = new[] { "label" }
                });

            var wrapperSummary = new SemaphoreSummaryWrapper(summary);
            var wrapperSummaryAsync = new SemaphoreSummaryWrapperAsync(summary);
            int seconds = 60;

            MeasureScenario("TestConcurrentWrapper", seconds, () => TestConcurrentWrapper(wrapperSummary), true);
            MeasureScenario("TestConcurrentSummary", seconds, () => TestConcurrentSummary(summary), true);
            MeasureScenario("TestSequentialWrapper", seconds, () => TestSequentialWrapper(wrapperSummary), true);
            MeasureScenario("TestSequentialSummary", seconds, () => TestSequentialSummary(summary), true);
            await MeasureScenarioAsync("TestConcurrentWrapperAsync", seconds,
                () => TestConcurrentWrapperAsync(wrapperSummaryAsync), true);
            await MeasureScenarioAsync("TestSequentialWrapperAsync", seconds,
                () => TestSequentialWrapperAsync(wrapperSummaryAsync), true);

            MeasureScenario("TestConcurrentWrapper", seconds, () => TestConcurrentWrapper(wrapperSummary));
            MeasureScenario("TestConcurrentSummary", seconds, () => TestConcurrentSummary(summary));
            MeasureScenario("TestSequentialWrapper", seconds, () => TestSequentialWrapper(wrapperSummary));
            MeasureScenario("TestSequentialSummary", seconds, () => TestSequentialSummary(summary));
            await MeasureScenarioAsync("TestConcurrentWrapperAsync", seconds,
                () => TestConcurrentWrapperAsync(wrapperSummaryAsync));
            await MeasureScenarioAsync("TestSequentialWrapperAsync", seconds,
                () => TestSequentialWrapperAsync(wrapperSummaryAsync));

            Console.WriteLine("Done...");
            Console.ReadKey();
        }

        static void MeasureScenario(string label, int seconds, Action action, bool isWarmup = false)
        {
            Stopwatch wallClock = new Stopwatch();
            var process = Process.GetCurrentProcess();
            int iterations = 0;
            TimeSpan startCpuTime = process.TotalProcessorTime;

            wallClock.Start();
            while (wallClock.ElapsedMilliseconds < seconds * 1000)
            {
                action.Invoke();
                iterations++;
            }

            wallClock.Stop();
            TimeSpan cpuTimeUsed = process.TotalProcessorTime - startCpuTime;

            if (isWarmup)
            {
                return;
            }

            Console.WriteLine($"{label} iterations in {seconds} seconds: {iterations}");
            Console.WriteLine(
                $"{label} - Wall Clock Time: {wallClock.ElapsedMilliseconds} ms, CPU Time: {cpuTimeUsed.TotalMilliseconds} ms");
            Console.WriteLine();
        }

        static async Task MeasureScenarioAsync(string label, int seconds, Func<Task> action, bool isWarmup = false)
        {
            Stopwatch wallClock = new Stopwatch();
            var process = Process.GetCurrentProcess();
            int iterations = 0;
            TimeSpan startCpuTime = process.TotalProcessorTime;

            wallClock.Start();
            while (wallClock.ElapsedMilliseconds < seconds * 1000)
            {
                await action.Invoke();
                iterations++;
            }

            wallClock.Stop();
            TimeSpan cpuTimeUsed = process.TotalProcessorTime - startCpuTime;

            if (isWarmup)
            {
                return;
            }

            Console.WriteLine($"{label} iterations in {seconds} seconds: {iterations}");
            Console.WriteLine(
                $"{label} - Wall Clock Time: {wallClock.ElapsedMilliseconds} ms, CPU Time: {cpuTimeUsed.TotalMilliseconds} ms");
            Console.WriteLine();
        }
    }
}
```

---

### Test Environment
- **OS**: Windows
- **.NET Version**: .NET Core 8 Release
- **Prometheus Library**: prometheus-net 8.2.1
- **Run Time**: 60 seconds
- **Comparing**: `Native Summary` vs. `SemaphoreSlim Wrapper` (both sync and async versions)

### Test Results Summary

| Test Scenario             | Iterations (in 60 sec) | CPU Time (ms) |
|---------------------------|------------------------|---------------|
| TestConcurrentWrapper     | 7805                   | 89,812.5      |
| TestConcurrentSummary     | 8829                   | 239,593.75    |
| TestSequentialWrapper     | 13,977                 | 56,437.5      |
| TestSequentialSummary     | 14,351                 | 56,203.125    |
| TestConcurrentWrapperAsync| 13,591                 | 56,484.375    |
| TestSequentialWrapperAsync| 13,407                 | 56,421.875    |

---

### Analysis
- **Synchronous version (`SemaphoreSlim.Wait`)**:
  - In the concurrent test (`TestConcurrentWrapper`), CPU usage dropped significantly compared to the original `Summary` implementation (`TestConcurrentSummary`) (~89,812 ms vs. ~239,593 ms).
- **Asynchronous version (`SemaphoreSlim.WaitAsync`)**:
  - The concurrent test (`TestConcurrentWrapperAsync`) shows the same CPU usage and iterations as the sequential test, meaning it effectively reduces contention while maintaining high throughput.
- **Production relevance**:
  - In our production environment, we have encountered peak QPS causing lock contention and leading to unbounded CPU growth. Using `SemaphoreSlim` should resolve this issue.
- **Low-concurrency scenarios**:
  - The execution time remains nearly identical, proving that the optimization does not negatively impact low-concurrency performance.

---

### Which Version Do You Prefer? (`SemaphoreSlim.Wait` or `SemaphoreSlim.WaitAsync`)?
I personally prefer **`SemaphoreSlim.WaitAsync`**, as it provides better performance in high-concurrency scenarios. However, it would break a few unit tests because the update might be delayed. We can let the unit tests to await one second before checking but it is not elegant. If you want to keep the implementation synchronous, **`SemaphoreSlim.Wait`** is still a great improvement over `lock` too.

#### Comparison of Implementation
✅ **Synchronous Version (`SemaphoreSlim.Wait`)**

```csharp
try
{
    _bufLock.Wait();
    if (nowUnixtimeSeconds > _hotBufExpUnixtimeSeconds)
        Flush(nowUnixtimeSeconds);

    _hotBuf.Append(val);

    if (_hotBuf.IsFull)
        Flush(nowUnixtimeSeconds);
}
finally
{
    _bufLock.Release();
}

Publish();
```

✅ **Asynchronous Version (`SemaphoreSlim.WaitAsync`)**

```csharp
_ = Task.Run(async () =>
{
    try
    {
        await _bufLock.WaitAsync();
        if (nowUnixtimeSeconds > _hotBufExpUnixtimeSeconds)
            Flush(nowUnixtimeSeconds);

        _hotBuf.Append(val);

        if (_hotBuf.IsFull)
            Flush(nowUnixtimeSeconds);
    }
    finally
    {
        _bufLock.Release();
    }

    Publish();
});
```