### PR TITLE
feat: .NET 9 gauge support

### DIFF
--- a/Benchmark.NetCore/Benchmark.NetCore.csproj
+++ b/Benchmark.NetCore/Benchmark.NetCore.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<SignAssembly>true</SignAssembly>
 
 		<AssemblyOriginatorKeyFile>..\Resources\prometheus-net.snk</AssemblyOriginatorKeyFile>

--- a/Benchmark.NetCore/MeterAdapterBenchmarks.cs
+++ b/Benchmark.NetCore/MeterAdapterBenchmarks.cs
@@ -19,6 +19,10 @@ public class MeterAdapterBenchmarks
     private readonly SDM.Counter<double> _floatCounter;
     private readonly SDM.Histogram<long> _intHistogram;
     private readonly SDM.Histogram<double> _floatHistogram;
+#if NET9_0_OR_GREATER
+    private readonly SDM.Gauge<long> _intGauge;
+    private readonly SDM.Gauge<double> _floatGauge;
+#endif
 
     private readonly CollectorRegistry _registry;
 
@@ -32,6 +36,10 @@ public class MeterAdapterBenchmarks
         _floatCounter = _meter.CreateCounter<double>("float_counter", description: "This is a floating-point counter.");
         _intHistogram = _meter.CreateHistogram<long>("int_histogram", description: "This is an integer histogram.");
         _floatHistogram = _meter.CreateHistogram<double>("float_histogram", description: "This is a floating-point histogram.");
+#if NET9_0_OR_GREATER
+        _intGauge = _meter.CreateGauge<long>("int_gauge", description: "This is an integer gauge.");
+        _floatGauge = _meter.CreateGauge<double>("float_gauge", description: "This is a floating-point gauge.");
+#endif
 
         _registry = Metrics.NewCustomRegistry();
 
@@ -49,6 +57,10 @@ public class MeterAdapterBenchmarks
         _floatCounter.Add(1, _label);
         _intHistogram.Record(1, _label);
         _floatHistogram.Record(1, _label);
+#if NET9_0_OR_GREATER
+        _intGauge.Record(1, _label);
+        _floatGauge.Record(1, _label);
+#endif
     }
 
     [GlobalCleanup]
@@ -92,4 +104,24 @@ public class MeterAdapterBenchmarks
             _floatHistogram.Record(i, _label);
         }
     }
+
+#if NET9_0_OR_GREATER
+    [Benchmark]
+    public void GaugeInt()
+    {
+        for (var i = 0; i < MeasurementCount; i++)
+        {
+            _intGauge.Record(i, _label);
+        }
+    }
+
+    [Benchmark]
+    public void GaugeFloat()
+    {
+        for (var i = 0; i < MeasurementCount; i++)
+        {
+            _floatGauge.Record(i, _label);
+        }
+    }
+#endif
 }

--- a/History
+++ b/History
@@ -1,3 +1,5 @@
+* 8.3.0
+- Added Gauge support to MeterAdapter (.NET 9 specific feature).
 * 8.2.1
 - Fix occasional "Collection was modified" exception when serializing metrics. #464
 * 8.2.0

--- a/Prometheus/MeterAdapter.cs
+++ b/Prometheus/MeterAdapter.cs
@@ -183,6 +183,9 @@ public sealed class MeterAdapter : IDisposable
 #if NET7_0_OR_GREATER
                 or ObservableUpDownCounter<TMeasurement>
 #endif
+#if NET9_0_OR_GREATER
+                or Gauge<TMeasurement>
+#endif
                 )
             {
                 var context = GetOrCreateGaugeContext(instrument, tags);

--- a/Prometheus/Prometheus.csproj
+++ b/Prometheus/Prometheus.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-		<TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0;net9.0;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-		<TargetFrameworks>net462;net6.0;net7.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net462;net6.0;net7.0;net9.0;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Resources/SolutionAssemblyInfo.cs
+++ b/Resources/SolutionAssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 
 // This is the real version number, used in NuGet packages and for display purposes.
-[assembly: AssemblyFileVersion("8.2.1")]
+[assembly: AssemblyFileVersion("8.3.0")]
 
 // Only use major version here, with others kept at zero, for correct assembly binding logic.
 [assembly: AssemblyVersion("8.0.0")]

--- a/Tests.NetCore/MeterAdapterTests.cs
+++ b/Tests.NetCore/MeterAdapterTests.cs
@@ -17,6 +17,7 @@ public sealed class MeterAdapterTests : IDisposable
     private readonly SDM.Meter _meter = new("test");
     private readonly SDM.Counter<long> _intCounter;
     private readonly SDM.Counter<double> _floatCounter;
+    private readonly SDM.Gauge<long> _intGauge;
     private readonly IDisposable _adapter;
 
     public MeterAdapterTests()
@@ -26,7 +27,9 @@ public sealed class MeterAdapterTests : IDisposable
 
         _intCounter = _meter.CreateCounter<long>("int_counter");
         _floatCounter = _meter.CreateCounter<double>("float_counter");
-
+#if NET9_0_OR_GREATER
+        _intGauge = _meter.CreateGauge<long>("int_gauge");
+#endif
         _registry = Metrics.NewCustomRegistry();
         _metrics = Metrics.WithCustomRegistry(_registry);
 
@@ -142,6 +145,21 @@ public sealed class MeterAdapterTests : IDisposable
         Assert.AreEqual(1002, GetValue("test_int_counter"));
         Assert.AreEqual(1, GetValue(registry2, "test_int_counter"));
     }
+
+#if NET9_0_OR_GREATER
+    [TestMethod]
+    public void GaugeInt()
+    {
+        _intGauge.Record(42);
+        Assert.AreEqual(42, GetValue("test_int_gauge"));
+
+        _intGauge.Record(10);
+        Assert.AreEqual(10.0, GetValue("test_int_gauge"));
+
+        _intGauge.Record(123, new KeyValuePair<string, object>("label1", "value1"));
+        Assert.AreEqual(123, GetValue("test_int_gauge", ("label1", "value1")));
+    }
+#endif
 
     public void Dispose()
     {

--- a/Tests.NetCore/Tests.NetCore.csproj
+++ b/Tests.NetCore/Tests.NetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Adding compatibility with native .NET 9 `Gauge` support: https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics.gauge-1?view=net-9.0